### PR TITLE
[ATOM-14295] AZSLc Crashes on Undefined Function

### DIFF
--- a/.github/workflows/configaction_azslc.yml
+++ b/.github/workflows/configaction_azslc.yml
@@ -45,6 +45,5 @@ jobs:
     # Build and execute all the tests for Debug & Release
     - name: Build and Execute AZSLc tests
       run: |
-        cd Overhaul
         export PYTHONPATH=${PYTHONPATH}:`pwd`
         python test.and.py

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,7 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR    "7"
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "23" // ATOM-15801
+#define AZSLC_REVISION "24" // ATOM-14295
 
 namespace AZ::ShaderCompiler
 {

--- a/src/AzslcReflection.cpp
+++ b/src/AzslcReflection.cpp
@@ -330,7 +330,8 @@ namespace AZ::ShaderCompiler
             UnqualifiedNameView funcName = ExtractLeaf(uid.m_name);
 
             bool validFunc = (IsGlobal(uid.m_name)
-                              && (psEntry == nullptr || strcmp(psEntry, funcName.data()) == 0));
+                              && (psEntry == nullptr || strcmp(psEntry, funcName.data()) == 0)
+                              && sym->m_defNode); // Regarding OM data, only defined functions are relevant.
             if (!validFunc)
             {   // It's not the function we are looking for
                 continue;

--- a/tests/Emission/undefined-func-om.azsl
+++ b/tests/Emission/undefined-func-om.azsl
@@ -1,0 +1,1 @@
+void func(int a);

--- a/tests/Emission/undefined-func-om.txt
+++ b/tests/Emission/undefined-func-om.txt
@@ -1,0 +1,4 @@
+/*
+   In the past, functions without definition blocks would crash the Output Merger emission.
+   Cmdargs: ['--om']
+*/


### PR DESCRIPTION
This is version 1.7.24

The Output Merger emission was crashing on any undefined function.

In this version, if a function only has declaration but no definition it will be skipped
for Output Merger analysis.

Signed-off-by: garrieta <garrieta@amazon.com>