### PR TITLE
The HLSL file should preserve the original line numbers

### DIFF
--- a/src/AzslcEmitter.cpp
+++ b/src/AzslcEmitter.cpp
@@ -488,7 +488,7 @@ namespace AZ::ShaderCompiler
 
     void CodeEmitter::EmitStruct(const ClassInfo& classInfo, string_view structName, const Options& options)
     {
-        EmitNewLinesAsNecessary(classInfo.GetOriginalLineNumber());
+        EmitEmptyLinesToLineNumber(classInfo.GetOriginalLineNumber());
 
         const bool hasName = (structName.length() > 0);
         const auto tabs = "    ";
@@ -669,7 +669,7 @@ namespace AZ::ShaderCompiler
 
     void CodeEmitter::EmitEnum(const IdentifierUID& uid, const ClassInfo& classInfo, const Options& options)
     {
-        EmitNewLinesAsNecessary(classInfo.GetOriginalLineNumber());
+        EmitEmptyLinesToLineNumber(classInfo.GetOriginalLineNumber());
 
         const auto& enumInfo = get<EnumerationInfo>(classInfo.m_subInfo);
 
@@ -720,7 +720,7 @@ namespace AZ::ShaderCompiler
 
         AstFuncSig* node = funcSub.m_defNode ? funcSub.m_defNode : funcSub.m_declNode;
 
-        EmitNewLinesAsNecessary(funcSub.GetOriginalLineNumber(emitAsDefinition));
+        EmitEmptyLinesToLineNumber(funcSub.GetOriginalLineNumber(emitAsDefinition));
 
         EmitAllAttachedAttributes(uid);
 
@@ -856,7 +856,7 @@ namespace AZ::ShaderCompiler
 
     void CodeEmitter::EmitVariableDeclaration(const VarInfo& varInfo, const IdentifierUID& uid, const Options& options, VarDeclHasFlag declOptions) const
     {
-        EmitNewLinesAsNecessary(varInfo.GetOriginalLineNumber());
+        EmitEmptyLinesToLineNumber(varInfo.GetOriginalLineNumber());
 
         // from MSDN: https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/dx-graphics-hlsl-variable-syntax
         // [Storage_Class] [Type_Modifier] Type Name[Index] [: Semantic] [: Packoffset] [: Register]; [Annotations] [= Initial_Value]
@@ -1037,7 +1037,7 @@ namespace AZ::ShaderCompiler
         const auto* varInfo = m_ir->GetSymbolSubAs<VarInfo>(cId.m_name);
         auto cbName = ReplaceSeparators(cId.m_name, Underscore);
 
-        EmitNewLinesAsNecessary(varInfo->GetOriginalLineNumber());
+        EmitEmptyLinesToLineNumber(varInfo->GetOriginalLineNumber());
 
         assert(varInfo->IsConstantBuffer());
         // note: instead of redoing this work ad-hoc, EmitText could be used directly on the ext type.
@@ -1064,7 +1064,7 @@ namespace AZ::ShaderCompiler
         const auto& bindInfo = rootSig.Get(sId);
         const auto* varInfo = m_ir->GetSymbolSubAs<VarInfo>(sId.m_name);
 
-        EmitNewLinesAsNecessary(varInfo->GetOriginalLineNumber());
+        EmitEmptyLinesToLineNumber(varInfo->GetOriginalLineNumber());
 
         const string spaceX = (options.m_useLogicalSpaces) ? ", space" + std::to_string(bindInfo.m_registerBinding.m_pair[bindSet].m_logicalSpace) : "";
         m_out << (varInfo->m_samplerState->m_isComparison ? "SamplerComparisonState " : "SamplerState ")
@@ -1117,7 +1117,7 @@ namespace AZ::ShaderCompiler
             stringifiedLogicalSpace = std::to_string(bindInfo.m_registerBinding.m_pair[bindSet].m_logicalSpace);
         }
 
-        EmitNewLinesAsNecessary(varInfo->GetOriginalLineNumber());
+        EmitEmptyLinesToLineNumber(varInfo->GetOriginalLineNumber());
 
         // depending on platforms we may have supplementary attributes or/and type modifier.
         auto [prefix, suffix] = GetPlatformEmitter().GetDataViewHeaderFooter(*this, tId, bindInfo.m_registerBinding.m_pair[bindSet].m_registerIndex, registerTypeLetter, stringifiedLogicalSpace);
@@ -1201,7 +1201,7 @@ namespace AZ::ShaderCompiler
         RootSigDesc::SrgDesc srgDesc;
         srgDesc.m_uid = srgId;
 
-        EmitNewLinesAsNecessary(srgInfo.GetOriginalLineNumber());
+        EmitEmptyLinesToLineNumber(srgInfo.GetOriginalLineNumber());
 
         m_out << "/* Generated code from ";
         // We don't emit the SRG attributes (only as a comment), but they can be accessed by the srgId if needed
@@ -1268,7 +1268,7 @@ namespace AZ::ShaderCompiler
             
             if (emitNewLines)
             {
-                EmitNewLinesAsNecessary(token->getLine());
+                EmitEmptyLinesToLineNumber(token->getLine());
             }
 
             const auto tokenIndex = token->getTokenIndex();
@@ -1356,7 +1356,7 @@ namespace AZ::ShaderCompiler
         GetTextInStream(interval, Backend::m_out);
     }
 
-    void CodeEmitter::EmitNewLinesAsNecessary(size_t originalLineNumber) const
+    void CodeEmitter::EmitEmptyLinesToLineNumber(size_t originalLineNumber) const
     {
         while (m_out.GetLineCount() < originalLineNumber)
         {

--- a/src/AzslcEmitter.cpp
+++ b/src/AzslcEmitter.cpp
@@ -488,6 +488,8 @@ namespace AZ::ShaderCompiler
 
     void CodeEmitter::EmitStruct(const ClassInfo& classInfo, string_view structName, const Options& options)
     {
+        EmitNewLinesAsNecessary(classInfo.GetOriginalLineNumber());
+
         const bool hasName = (structName.length() > 0);
         const auto tabs = "    ";
         if (hasName)
@@ -599,7 +601,7 @@ namespace AZ::ShaderCompiler
 
     void CodeEmitter::EmitAttribute(const AttributeInfo& attrInfo) const
     {
-        return EmitAttribute(attrInfo, m_out);
+        return EmitAttribute(attrInfo, Backend::m_out);
     }
 
     void CodeEmitter::EmitAttribute(const AttributeInfo& attrInfo, std::ostream& outstream)
@@ -667,6 +669,8 @@ namespace AZ::ShaderCompiler
 
     void CodeEmitter::EmitEnum(const IdentifierUID& uid, const ClassInfo& classInfo, const Options& options)
     {
+        EmitNewLinesAsNecessary(classInfo.GetOriginalLineNumber());
+
         const auto& enumInfo = get<EnumerationInfo>(classInfo.m_subInfo);
 
         EmitAllAttachedAttributes(uid);
@@ -715,6 +719,8 @@ namespace AZ::ShaderCompiler
         }
 
         AstFuncSig* node = funcSub.m_defNode ? funcSub.m_defNode : funcSub.m_declNode;
+
+        EmitNewLinesAsNecessary(funcSub.GetOriginalLineNumber(emitAsDefinition));
 
         EmitAllAttachedAttributes(uid);
 
@@ -850,6 +856,8 @@ namespace AZ::ShaderCompiler
 
     void CodeEmitter::EmitVariableDeclaration(const VarInfo& varInfo, const IdentifierUID& uid, const Options& options, VarDeclHasFlag declOptions) const
     {
+        EmitNewLinesAsNecessary(varInfo.GetOriginalLineNumber());
+
         // from MSDN: https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/dx-graphics-hlsl-variable-syntax
         // [Storage_Class] [Type_Modifier] Type Name[Index] [: Semantic] [: Packoffset] [: Register]; [Annotations] [= Initial_Value]
         // example of valid HLSL statement:
@@ -1029,6 +1037,8 @@ namespace AZ::ShaderCompiler
         const auto* varInfo = m_ir->GetSymbolSubAs<VarInfo>(cId.m_name);
         auto cbName = ReplaceSeparators(cId.m_name, Underscore);
 
+        EmitNewLinesAsNecessary(varInfo->GetOriginalLineNumber());
+
         assert(varInfo->IsConstantBuffer());
         // note: instead of redoing this work ad-hoc, EmitText could be used directly on the ext type.
         const auto genericType = "<" + GetTranslatedName(varInfo->m_typeInfoExt.m_genericParameter, UsageContext::ReferenceSite) + ">";
@@ -1053,6 +1063,8 @@ namespace AZ::ShaderCompiler
 
         const auto& bindInfo = rootSig.Get(sId);
         const auto* varInfo = m_ir->GetSymbolSubAs<VarInfo>(sId.m_name);
+
+        EmitNewLinesAsNecessary(varInfo->GetOriginalLineNumber());
 
         const string spaceX = (options.m_useLogicalSpaces) ? ", space" + std::to_string(bindInfo.m_registerBinding.m_pair[bindSet].m_logicalSpace) : "";
         m_out << (varInfo->m_samplerState->m_isComparison ? "SamplerComparisonState " : "SamplerState ")
@@ -1104,6 +1116,8 @@ namespace AZ::ShaderCompiler
         {
             stringifiedLogicalSpace = std::to_string(bindInfo.m_registerBinding.m_pair[bindSet].m_logicalSpace);
         }
+
+        EmitNewLinesAsNecessary(varInfo->GetOriginalLineNumber());
 
         // depending on platforms we may have supplementary attributes or/and type modifier.
         auto [prefix, suffix] = GetPlatformEmitter().GetDataViewHeaderFooter(*this, tId, bindInfo.m_registerBinding.m_pair[bindSet].m_registerIndex, registerTypeLetter, stringifiedLogicalSpace);
@@ -1187,11 +1201,12 @@ namespace AZ::ShaderCompiler
         RootSigDesc::SrgDesc srgDesc;
         srgDesc.m_uid = srgId;
 
-        m_out << "/* Generated code from\n";
+        EmitNewLinesAsNecessary(srgInfo.GetOriginalLineNumber());
+
+        m_out << "/* Generated code from ";
         // We don't emit the SRG attributes (only as a comment), but they can be accessed by the srgId if needed
         EmitAllAttachedAttributes(srgId);
-        m_out << "ShaderResourceGroup " << srgInfo.m_declNode->Name->getText() << "\n";
-        m_out << "*/\n";
+        m_out << " ShaderResourceGroup " << srgInfo.m_declNode->Name->getText() << "*/\n";
 
         for (const auto& t : srgInfo.m_srViews)
         {
@@ -1240,7 +1255,8 @@ namespace AZ::ShaderCompiler
     }
 
     // override of the base method, to incorporate symbol and expression mutations
-    void CodeEmitter::GetTextInStream(misc::Interval interval, std::ostream& output) const
+    template <class StreamLike>
+    void CodeEmitter::GetTextInStreamInternal(misc::Interval interval, StreamLike& output, bool emitNewLines) const
     {
         const ICodeEmissionMutator* codeMutator = m_codeMutator;
 
@@ -1249,6 +1265,12 @@ namespace AZ::ShaderCompiler
         while (ii <= interval.b)
         {
             auto* token = GetNextToken(ii /*inout*/);
+            
+            if (emitNewLines)
+            {
+                EmitNewLinesAsNecessary(token->getLine());
+            }
+
             const auto tokenIndex = token->getTokenIndex();
 
             const CodeMutation* codeMutation = codeMutator ? codeMutator->GetMutation(tokenIndex) : nullptr;
@@ -1316,9 +1338,29 @@ namespace AZ::ShaderCompiler
         }
     }
 
+    void CodeEmitter::GetTextInStream(misc::Interval interval, std::ostream& output) const
+    {
+        if (m_out.IsTheSameStream(output))
+        {
+            GetTextInStreamInternal(interval, m_out, true);
+        }
+        else
+        {
+            GetTextInStreamInternal(interval, output, false);
+        }
+    }
+
     void CodeEmitter::EmitText(misc::Interval interval) const
     {
         // extract interval (with necessary internal translations) and add it to m_out stream
-        GetTextInStream(interval, m_out);
+        GetTextInStream(interval, Backend::m_out);
+    }
+
+    void CodeEmitter::EmitNewLinesAsNecessary(size_t originalLineNumber) const
+    {
+        while (m_out.GetLineCount() < originalLineNumber)
+        {
+            m_out << "\n";
+        }
     }
 }

--- a/src/AzslcEmitter.h
+++ b/src/AzslcEmitter.h
@@ -220,7 +220,7 @@ namespace AZ::ShaderCompiler
         //! Each symbol has an original line number where it appeared and if the number of output lines
         //! is less We fill with '\n' (new line) characters until they match.
         mutable NewLineCounterStream m_out;
-        void EmitNewLinesAsNecessary(size_t originalLineNumber) const;
+        void EmitEmptyLinesToLineNumber(size_t originalLineNumber) const;
 
         // This template takes over the previous implementation of
         // void GetTextInStream(misc::Interval interval, std::ostream& output) const override;

--- a/src/AzslcIntermediateRepresentation.cpp
+++ b/src/AzslcIntermediateRepresentation.cpp
@@ -336,7 +336,7 @@ namespace AZ::ShaderCompiler
             case Kind::Enum:
             {
                 auto& sub = sym.GetSubRefAs<ClassInfo>();
-                cout << "  line: " << sub.GetOrigSourceLine() << "\n";
+                cout << "  line: " << sub.GetOriginalLineNumber() << "\n";
                 cout << "  members:\n";
                 for (auto&& member : sub.GetOrderedMembers())
                 {
@@ -868,7 +868,7 @@ namespace AZ::ShaderCompiler
             // Let's get the line number where @insertBeforeThisUid was found in the flat AZSL file.
             const auto * tmpThis = this; // To disambiguate which version of GetSymbolSubAs<> to call.
             const auto * varInfo = tmpThis->GetSymbolSubAs<VarInfo>(insertBeforeThisUid.GetName());
-            size_t lineOfDeclaration = varInfo->GetLineOfDeclaration();
+            size_t lineOfDeclaration = varInfo->GetOriginalLineNumber();
             const LineDirectiveInfo* lineInfo = GetNearestPreprocessorLineDirective(lineOfDeclaration);
             if (!lineInfo)
             {

--- a/src/AzslcKindInfo.h
+++ b/src/AzslcKindInfo.h
@@ -162,7 +162,7 @@ namespace AZ::ShaderCompiler
                                    }, m_declNodeVt);
         }
 
-        size_t GetOrigSourceLine() const
+        size_t GetOriginalLineNumber() const
         {
             if (GetDeclNode())
             {
@@ -346,7 +346,7 @@ namespace AZ::ShaderCompiler
         // returns an ArrayDimensions struct const ref.
         inline const auto&         GetArrayDimensions() const;
         // Returns the line number, in the AZSL file, where this symbol is declared. 
-        inline size_t GetLineOfDeclaration () const;
+        inline size_t GetOriginalLineNumber () const;
 
         AstUnnamedVarDecl*         m_declNode = nullptr;
         UnqualifiedName            m_identifier;
@@ -433,7 +433,7 @@ namespace AZ::ShaderCompiler
         return m_typeInfoExt.GetDimensions();
     }
 
-    size_t VarInfo::GetLineOfDeclaration() const
+    size_t VarInfo::GetOriginalLineNumber() const
     {
         if (m_declNode)
         {
@@ -729,6 +729,19 @@ namespace AZ::ShaderCompiler
             }
         }
 
+        size_t GetOriginalLineNumber(bool useDefNode = true) const
+        {
+            if (useDefNode && m_defNode)
+            {
+                return m_defNode->start->getLine();
+            }
+            else if (m_declNode)
+            {
+                return m_declNode->start->getLine();
+            }
+            return 0;
+        }
+
         ExtendedTypeInfo          m_returnType;
         AstFuncSig*               m_declNode     = nullptr;   //!< point to the AST node first declaring this function
         AstFuncSig*               m_defNode      = nullptr;   //!< point to the AST node defining this function
@@ -774,6 +787,11 @@ namespace AZ::ShaderCompiler
         }
 
         bool IsPartial() const { return m_declNode ? !!m_declNode->Partial() : false; }
+
+        size_t GetOriginalLineNumber() const
+        {
+            return m_declNode ? m_declNode->start->getLine() : 0;
+        }
 
         AstSRGDeclNode*           m_declNode = nullptr;
         ClassInfo                 m_implicitStruct;           // Implicit holding struct for SRG Constants
@@ -1043,17 +1061,17 @@ namespace AZ::ShaderCompiler
 
         size_t operator()(const FunctionInfo& func) const
         {
-            return func.m_declNode ? func.m_declNode->start->getLine() : NoLine;
+            return func.GetOriginalLineNumber(false /*useDefNode*/);
         }
 
         size_t operator()(const ClassInfo& clInfo) const
         {
-            return clInfo.GetOrigSourceLine();
+            return clInfo.GetOriginalLineNumber();
         }
 
         size_t operator()(const SRGInfo& srgInfo) const
         {
-            return srgInfo.m_declNode ? srgInfo.m_declNode->start->getLine() : NoLine;
+            return srgInfo.GetOriginalLineNumber();
         }
 
         size_t operator()(const TypeAliasInfo& tai) const

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,7 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR    "7"
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "30" // AZSLc Crash On Shader Option With Undefined Type
+#define AZSLC_REVISION "31" // AZSLc: The HLSL file should preserve the original line numbers
 
 namespace AZ::ShaderCompiler
 {

--- a/src/DiagnosticStream.h
+++ b/src/DiagnosticStream.h
@@ -53,11 +53,11 @@ namespace AZ
         typedef DiagnosticStream Self;
 
         template< typename Any >
-        Self& operator<< (Any&& thing)  // universal reference
+        Self& operator<< (Any&& thing)
         {
             if (m_on && PassLevelFilter())
             {
-                m_wrappedStream << thing;
+                m_wrappedStream << std::forward<Any>(thing);
             }
 
             if (AsError() && m_onErrorCallback)

--- a/src/NewLineCounterStream.h
+++ b/src/NewLineCounterStream.h
@@ -22,7 +22,7 @@ namespace AZ
 
     public:
 
-        NewLineCounterStream(std::ostream& streamToWrap) : m_wrappedStream(streamToWrap)
+        explicit NewLineCounterStream(std::ostream& streamToWrap) : m_wrappedStream(streamToWrap)
         {}
 
         Self& operator<<(char c)
@@ -51,9 +51,9 @@ namespace AZ
 
         Self& operator<<(const std::string& str)
         {
-            for (auto it = str.begin(); it != str.end(); ++it )
+            for (char c : str)
             {
-                if (*it == '\n')
+                if (c == '\n')
                 {
                     m_lineCount++;
                 }
@@ -63,9 +63,9 @@ namespace AZ
         }
 
         template <class Any>
-        Self& operator<<(Any&& thing) // universal reference
+        Self& operator<<(Any&& thing)
         {
-            m_wrappedStream << thing;
+            m_wrappedStream << std::forward<Any>(thing);
             return *this;
         }
 

--- a/src/NewLineCounterStream.h
+++ b/src/NewLineCounterStream.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "ReflectableEnums.h"
+
+#include <ostream>
+
+namespace AZ
+{
+    //! Wraps and forwards data to a std::ostream,
+    //! Overrides operator<< for char, const char * and string data and counts
+    //! the number of '\n' (new line) characters that go through it.
+    class NewLineCounterStream
+    {
+        typedef NewLineCounterStream Self;
+
+    public:
+
+        NewLineCounterStream(std::ostream& streamToWrap) : m_wrappedStream(streamToWrap)
+        {}
+
+        Self& operator<<(char c)
+        {
+            if (c == '\n')
+            {
+                m_lineCount++;
+            }
+            m_wrappedStream << c;
+            return *this;
+        }
+
+        Self& operator<<(const char * nts)
+        {
+            const char * tmp = nts;
+            while(char c = *tmp++)
+            {
+                if (c == '\n')
+                {
+                    m_lineCount++;
+                }
+            }
+            m_wrappedStream << nts;
+            return *this;
+        }
+
+        Self& operator<<(const std::string& str)
+        {
+            for (auto it = str.begin(); it != str.end(); ++it )
+            {
+                if (*it == '\n')
+                {
+                    m_lineCount++;
+                }
+            }
+            m_wrappedStream << str;
+            return *this;
+        }
+
+        template <class Any>
+        Self& operator<<(Any&& thing) // universal reference
+        {
+            m_wrappedStream << thing;
+            return *this;
+        }
+
+        int GetLineCount() const { return m_lineCount; }
+
+        bool IsTheSameStream(std::ostream& stream) const { return &stream == &m_wrappedStream; } 
+
+    private:
+        std::ostream& m_wrappedStream;
+        int m_lineCount = 0;
+    };
+}


### PR DESCRIPTION
This version 1.7.30

Added a new class NewLineCounterStream that can wrap a ostream instance.
All strings that are streamed into NewLineCounterStream are scanned for
the '\n' (new line) character. Each '\n' character found is counted.

With the help of NewLineCounterStream, which is instantiated as
CodeEmitter::m_out, We can appoximate the output line number of the
HLSL symbols to be as close as possible to the input line number from
the AZSL file for the corresponding symbols.

The line numbers are simply matched by adding new lines to the
output file only if the current line number of the symbol about to be
output is less than the original line number.

The idea is that later if there are errors in the HLSL file, when
compiled with other tools like DXC, the error line number will be very
close (+/-) 2 lines to the original line number.

Signed-off-by: garrieta <garrieta@amazon.com>