### PR TITLE
AZSLc Crash On Shader Option With Undefined Type

### DIFF
--- a/src/AzslcException.h
+++ b/src/AzslcException.h
@@ -71,6 +71,7 @@ namespace AZ::ShaderCompiler
         ORCHESTRATOR_TRYING_TO_EXTEND_NOT_PARTIAL_SRG = 46u,
         ORCHESTRATOR_SRG_EXTENSION_HAS_DIFFERENT_SEMANTIC = 47u,
         ORCHESTRATOR_UNBOUNDED_RESOURCE_ISSUE = 48u,
+        ORCHESTRATOR_UNKNOWN_OPTION_TYPE = 49u,
 
 
         // Treat all compiler warnings as errors

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,7 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR    "7"
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "29" // ATOM-16433
+#define AZSLC_REVISION "30" // AZSLc Crash On Shader Option With Undefined Type
 
 namespace AZ::ShaderCompiler
 {

--- a/src/AzslcSemanticOrchestrator.cpp
+++ b/src/AzslcSemanticOrchestrator.cpp
@@ -570,7 +570,7 @@ namespace AZ::ShaderCompiler
             if (!varInfo.m_typeInfoExt.IsClassFound())
             {
                 const string message = FormatString("Unknown type '%s' for shader option '%.*s'",
-                    varInfo.m_typeInfoExt.GetDisplayName().c_str(), uqNameView.size(), uqNameView.data());
+                    varInfo.m_typeInfoExt.GetDisplayName().c_str(), static_cast<int>(uqNameView.size()), uqNameView.data());
                 ThrowAzslcOrchestratorException(ORCHESTRATOR_UNKNOWN_OPTION_TYPE, ctx->start, message);
             }
             // we'll set that here, an option is better flagged as static const for simplicity during emission

--- a/src/AzslcSemanticOrchestrator.cpp
+++ b/src/AzslcSemanticOrchestrator.cpp
@@ -569,8 +569,8 @@ namespace AZ::ShaderCompiler
         {
             if (!varInfo.m_typeInfoExt.IsClassFound())
             {
-                const string message = FormatString("Unknown type '%s' for shader option '%s'",
-                    varInfo.m_typeInfoExt.GetDisplayName().c_str(), uqNameView.data());
+                const string message = FormatString("Unknown type '%s' for shader option '%.*s'",
+                    varInfo.m_typeInfoExt.GetDisplayName().c_str(), uqNameView.size(), uqNameView.data());
                 ThrowAzslcOrchestratorException(ORCHESTRATOR_UNKNOWN_OPTION_TYPE, ctx->start, message);
             }
             // we'll set that here, an option is better flagged as static const for simplicity during emission

--- a/src/AzslcSemanticOrchestrator.cpp
+++ b/src/AzslcSemanticOrchestrator.cpp
@@ -567,6 +567,12 @@ namespace AZ::ShaderCompiler
 
         if (isOption)
         {
+            if (!varInfo.m_typeInfoExt.IsClassFound())
+            {
+                const string message = FormatString("Unknown type '%s' for shader option '%s'",
+                    varInfo.m_typeInfoExt.GetDisplayName().c_str(), uqNameView.data());
+                ThrowAzslcOrchestratorException(ORCHESTRATOR_UNKNOWN_OPTION_TYPE, ctx->start, message);
+            }
             // we'll set that here, an option is better flagged as static const for simplicity during emission
             varInfo.m_typeQualifier |= StorageFlag::Static;
             varInfo.m_typeQualifier |= StorageFlag::Const;

--- a/tests/Semantic/AsError/unknown-option-type.azsl
+++ b/tests/Semantic/AsError/unknown-option-type.azsl
@@ -1,0 +1,27 @@
+// This file should not compile because the type of
+// the shader option 'o_myOption' is undefined.
+// #EC 49
+
+ShaderResourceGroupSemantic ExampleBinding 
+{
+    FrequencyId = 0; 
+    ShaderVariantFallback = 64;
+};
+
+ShaderResourceGroup ExampleSRG : ExampleBinding
+{
+    float4 m_color;
+};
+
+option WhatAmI o_myOption; 
+
+float4 MainPS() : SV_Target0
+{
+    float4 color = ExampleSRG::m_color;
+    if (o_myOption)
+    {
+        color += float4(1, 0, 0, 0);
+    }
+    return color;
+}
+


### PR DESCRIPTION
This is version 1.7.30

A clear error is now emitted when a shader option is of undefined type.

Previously it was only asserting and the user was NOT provided with
a message describing the root cause of the problem.

Signed-off-by: garrieta <garrieta@amazon.com>