### PR TITLE
non-initialized static const of any type seems to get a spurious 0

### DIFF
--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,7 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR    "7"
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "31" // AZSLc: The HLSL file should preserve the original line numbers
+#define AZSLC_REVISION "32" // non-initialized static const of any type seems to get a spurious 0 initializer
 
 namespace AZ::ShaderCompiler
 {

--- a/src/AzslcSemanticOrchestrator.cpp
+++ b/src/AzslcSemanticOrchestrator.cpp
@@ -1739,7 +1739,7 @@ namespace AZ::ShaderCompiler
         {
             if (!hasInitializer && isStaticConst)
             {
-                return int32_t{0}; // non-assigned statics are zero-initialized
+                return monostate{}; // non-initialized static constants will be zero-initialized appropriately by DXC.
             }
             else
             {

--- a/tests/Emission/comprehensive.txt
+++ b/tests/Emission/comprehensive.txt
@@ -39,7 +39,7 @@
 ":: MySRGOne_InnerStruct :: SpecMode sm = :: MySRGOne_InnerStruct :: SpecMode :: Rough ;"
 "bool same = sm == :: MySRGOne_m_structured1 [ i ] . m_spec ;"
 "return :: MySRGOne_m_structured1 [ i ] . m_diffuseColor ;"
-"g_staticInitIsZero = 0"
+"g_staticInitIsZero"
 "enum Nums"
 "Uno"
 "Dos"

--- a/tests/Emission/ordering.txt
+++ b/tests/Emission/ordering.txt
@@ -8,7 +8,7 @@
 "void M ( )"
 "m_e = E :: A ;"
 "void F ( )"
-"static const :: C g_c = 0 ;"
+"static const :: C g_c"
 "struct Srg1_S"
 "struct Srg1_SRGConstantsStruct"
 "float4 Srg1_m_f4 ;"

--- a/tests/Semantic/constantfolding-printout.azsl
+++ b/tests/Semantic/constantfolding-printout.azsl
@@ -13,10 +13,6 @@ __azslc_print_message(" == 1\n");
 
 static const int non_init;
 
-__azslc_print_message("@check predicate ");
-__azslc_print_symbol(non_init, __azslc_prtsym_constint_value);
-__azslc_print_message(" == 0\n");
-
 static const int indirect[2] = {1,2};
 static const int complex_init = indirect[1];
 


### PR DESCRIPTION
non-initialized static const of any type seems to get a spurious 0 initializer

This is version 1.7.32

Uninitialized static const variables now remain uninitilized.
The initialization value will be deferred to DXC which will
pick an appropriate value per HLSL spec.

Adjusted test cases.

Signed-off-by: garrieta <garrieta@amazon.com>