### PR TITLE
Improved project generation and compilation for Linux.

### DIFF
--- a/clean_build.sh
+++ b/clean_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+DIR_LIST=("bin/" "build/" "src/dist/" " src/external/antlr4/")
+for DIR in ${DIR_LIST[@]}; do
+    echo "Removing $DIR..."
+    rm -rf $DIR
+    echo "Done."
+done
+

--- a/prepare_solution_linux.sh
+++ b/prepare_solution_linux.sh
@@ -1,47 +1,57 @@
 #!/bin/bash
 
+
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
 # Build
 
-mkdir build
-mkdir build/release
-mkdir build/debug
-
 CMAKE='cmake'
+BUILD='build'
+mkdir ${BUILD}
 
-$CMAKE -DMAKE_BUILD_TYPE=Release -S "src/external/antlr4/runtime/Cpp/" -B "build/release/external/antlr4/runtime/Cpp/"
-pushd build/release/external/antlr4/runtime/Cpp
-make -j16
-popd
-
-$CMAKE -DMAKE_BUILD_TYPE=Release -S "src/" -B "build/release"
-pushd build/release
-echo "Building release..."
-make -j16
-ls
-echo "Release version:"
-./azslc --version
-popd
-
-$CMAKE -DMAKE_BUILD_TYPE=Debug -S "src/" -B "build/debug"
-pushd build/debug
-echo "Building debug..."
-make -j16
-ls
-echo "Debug version:"
-./azslc --version
-popd
-
-# Deploy
 mkdir bin
-mkdir bin/linux
-mkdir bin/linux/release
-mkdir bin/linux/debug
-cp build/release/azslc bin/linux/release/azslc
-cp build/debug/azslc bin/linux/debug/azslc
+LINUX_BIN_DIR='bin/linux'
+mkdir ${LINUX_BIN_DIR}
+
+CONFIGURATIONS=("Release" "Debug")
+MY_CC="/usr/bin/gcc"
+MY_CXX="/usr/bin/g++"
+EXTRA_CXX_OPTION=""
+
+NUM_ARGS=$#
+if [ $NUM_ARGS -eq 1 ]; then
+    if [ $1 = "clang" ]; then
+        MY_CC="clang-12"
+        MY_CXX="clang++-12"
+	EXTRA_CXX_OPTION="-DWITH_LIBCXX=Off" #Required by ANTLR to avoid failure to find std c++ include files like <algorithm>, etc.
+    fi
+fi
+
+for CONFIG in ${CONFIGURATIONS[@]}; do
+    echo ""
+    echo "Configuring for $CONFIG build..."
+    echo ""
+    BUILD_DIR=$BUILD/$CONFIG
+    $CMAKE -G "Unix Makefiles" -S "src/" -B $BUILD_DIR $EXTRA_CXX_OPTION -DCMAKE_BUILD_TYPE=$CONFIG -DCMAKE_C_COMPILER=$MY_CC -DCMAKE_CXX_COMPILER=$MY_CXX
+
+    echo "Will proceed to build in $CONFIG configuration..."
+    $CMAKE --build $BUILD_DIR --target azslc --config $CONFIG -j 16
+
+    pushd $BUILD_DIR
+    echo "Executing azslc in $CONFIG version:"
+    ./azslc --version
+    popd
+
+    echo "Deploying azslc $CONFIG binary..."
+    CONFIG_LCASE="$(tr [A-Z] [a-z] <<< "$CONFIG")"
+    DEPLOY_DIR=$LINUX_BIN_DIR/$CONFIG_LCASE
+    mkdir $DEPLOY_DIR
+    cp $BUILD_DIR/azslc $DEPLOY_DIR/
+    echo "azslc was deployed to $DEPLOY_DIR"
+done
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,8 @@ FetchContent_Declare(
   GIT_TAG o3de-4.9.3
   SOURCE_SUBDIR runtime/Cpp
   CMAKE_ARGS "-DCMAKE_BUILD_TYPE=Release"
+  GIT_SHALLOW TRUE
+  GIT_PROGRESS TRUE
 )
 
 FetchContent_MakeAvailable(cli11 antlr4)


### PR DESCRIPTION
In Linux, AZSLc can now be compiled with clang-12. By default it uses g++.

Optimized the git clone operation of ANTLR to do a shallow clone.

Added a helper script 'clean_build.sh' to clean the linux/mac build folders.

Signed-off-by: galibzon <garrieta@amazon.com>