### PR TITLE
Support multiple unbounded arrays within a single SRG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/*
 src/generated/*.interp
 src/generated/*.tokens
 src/generated/java/
+src/dist
 .vs
 build
 /src/.antlr/azslLexer.interp

--- a/Platform/Windows/src/DirectX12PlatformEmitter.cpp
+++ b/Platform/Windows/src/DirectX12PlatformEmitter.cpp
@@ -71,11 +71,14 @@ namespace AZ::ShaderCompiler
             {
                 if (param.m_type != RootParamType::SrgConstantCB && param.m_type != RootParamType::RootConstantCB) // already treated in the previous loop
                 {
+                    // In DX12, unbounded arrays are assigned their own space instead of using the space assigned to the SRG
+                    int space = param.m_isUnboundedArray ? param.m_spillSpace : param.m_registerBinding.m_pair[querySet].m_logicalSpace;
+
                     std::stringstream rootParam;
                     rootParam << RootParamType::ToStr(param.m_type)
                         << "(" << ToLower(BindingType::ToStr(RootParamTypeToBindingType(param.m_type)));  // eg "CBV(b" or "SRV(t" or "Sampler(s"
                     rootParam << std::to_string(param.m_registerBinding.m_pair[querySet].m_registerIndex)
-                        << ", space = " << std::to_string(param.m_registerBinding.m_pair[querySet].m_logicalSpace)
+                        << ", space = " << std::to_string(space)
                         << ", numDescriptors = " << std::to_string(param.m_registerRange) << ")";
 
                     const auto* memberInfo = codeEmitter.GetIR()->GetSymbolSubAs<VarInfo>(param.m_uid.m_name);
@@ -125,5 +128,4 @@ namespace AZ::ShaderCompiler
 
         return Decorate("#define sig ", Join(rootAttrList.begin(), rootAttrList.end(), ", \" \\\n"), "\"\n\n");
     }
-    
 }

--- a/Platform/Windows/src/DirectX12PlatformEmitter.h
+++ b/Platform/Windows/src/DirectX12PlatformEmitter.h
@@ -22,6 +22,8 @@ namespace AZ::ShaderCompiler
         [[nodiscard]]
         string GetRootSig(const CodeEmitter& codeEmitter, const RootSigDesc& rootSig, const Options& options, BindingPair::Set signatureQuery) const override final;
 
+        bool UnboundedArraysUseSpillSpace() const override { return true; }
+
     private:
         DirectX12PlatformEmitter() : PlatformEmitter {} {};
     };

--- a/src/AzslcBackend.h
+++ b/src/AzslcBackend.h
@@ -64,6 +64,9 @@ namespace AZ::ShaderCompiler
             BindingPair m_registerBinding;
             int m_registerRange = -1;
             int m_num32BitConstants = -1;
+
+            int m_spillSpace = -1;
+
             // This flag is added so m_registerRange can take the value
             // of 1 and at the same time We do not forget that m_uid refers
             // to an unbounded array.
@@ -98,6 +101,10 @@ namespace AZ::ShaderCompiler
         int GetAccumulated(BindingType r) const;
 
         int m_space = 0;  //<! logical space
+
+        // See: MultiBindingLocationMarker::m_unboundedSpillSpace
+        int m_unboundedSpillSpace;
+
         int m_registerPos[BindingType::EndEnumeratorSentinel_] = {0};   //!< register index, one by type.
         int m_accumulated[BindingType::EndEnumeratorSentinel_] = {0};  //!< Counter for total usage independently from space increments
         int m_accumulatedUnused[BindingType::EndEnumeratorSentinel_] = {0};  //!< Counter for holes created by indices unification
@@ -109,21 +116,28 @@ namespace AZ::ShaderCompiler
     class MultiBindingLocationMaker
     {
     public:
-        MultiBindingLocationMaker(const Options& options)
-            : m_options(options)
+        MultiBindingLocationMaker(const Options& options, int& unboundedSpillSpace)
+            : m_options{ options }
+            , m_unboundedSpillSpace{ unboundedSpillSpace }
         {}
 
         void SignalIncrementSpace(std::function<void(int, int)> warningMessageFunctionForMinDescOvershoot);
 
         void SignalUnifyIndices();
         
-        void SignalRegisterIncrement(BindingType regType, int count = 1);
+        void SignalRegisterIncrement(BindingType regType, int count, bool isUnbounded);
 
         BindingPair GetCurrent(BindingType regType);
 
         SingleBindingLocationTracker m_untainted;
         SingleBindingLocationTracker m_merged;
         Options m_options;
+
+        // On some platforms (DX12), descriptor arrays occupy an individual register slot, and spaces are used
+        // to prevent overlapping ranges. When an unbounded array is encountered, we immediately assign it to
+        // the value of this member variable and increment. This is initialized in the constructor because the
+        // space we spill to must not collide with any other SRG declared in the shader.
+        int& m_unboundedSpillSpace;
     };
 
     //! This class intends to be a base umbrella for compiler back-end services.
@@ -174,6 +188,9 @@ namespace AZ::ShaderCompiler
         std::ostream&               m_out;
         IntermediateRepresentation* m_ir;
         TokenStream*                m_tokens;
+
+        // See MultiBindingLocationMaker::m_unboundedSpillSpace
+        mutable int m_unboundedSpillSpace;
     };
 
     // independent utility functions

--- a/src/AzslcEmitter.h
+++ b/src/AzslcEmitter.h
@@ -228,5 +228,8 @@ namespace AZ::ShaderCompiler
         // whether We are using a regular std::ostream or an instance of NewLineCounterStream.
         template <class StreamLike>
         void GetTextInStreamInternal(misc::Interval interval, StreamLike& output, bool emitNewLines) const;
+
+        // Given an SRG parameter, determines the space it belongs to based on the platform
+        int ResolveBindingSpace(const RootSigDesc::SrgParamDesc& bindInfo, BindingPair::Set bindSet) const;
     };
 }

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -526,13 +526,6 @@ int main(int argc, const char* argv[])
             std::for_each(namespaces.begin(), namespaces.end(),
                 [&](const string& space) { ir.AddAttributeNamespaceFilter(space); });
 
-            UnboundedArraysValidator::Options unboundedArraysValidationOptions = { useSpaces, uniqueIdx };
-            if (*maxSpacesOpt)
-            {
-                unboundedArraysValidationOptions.m_maxSpaces = maxSpaces;
-            }
-            ir.m_sema.m_unboundedArraysValidator.SetOptions(unboundedArraysValidationOptions);
-
             // semantic logic and validation
             walker.walk(&semanticListener, tree);
 

--- a/src/AzslcPlatformEmitter.h
+++ b/src/AzslcPlatformEmitter.h
@@ -74,5 +74,7 @@ namespace AZ::ShaderCompiler
         //! Aligns the size for the data containing the root constants.
         //! @param size  The size of stride
         virtual uint32_t AlignRootConstants(uint32_t size) const;
+
+        virtual bool UnboundedArraysUseSpillSpace() const { return false; }
     };
 }

--- a/src/AzslcReflection.h
+++ b/src/AzslcReflection.h
@@ -43,6 +43,8 @@ namespace AZ::ShaderCompiler
         void DumpResourceBindingDependencies(const Options& options) const;
 
     private:
+        // Serialize a binding to Json
+        void ReflectBinding(Json::Value& output, const RootSigDesc::SrgParamDesc& bindInfo) const;
 
         //! Builds member variable packing information and adds it to the membersContainer
         uint32_t BuildMemberLayout(Json::Value& membersContainer, string_view namePrefix, const IdentifierUID& memberId, const bool isArrayItr, const Options& options, const AZ::ShaderCompiler::Packing::Layout layoutPacking, uint32_t& offset) const;

--- a/src/AzslcSemanticOrchestrator.cpp
+++ b/src/AzslcSemanticOrchestrator.cpp
@@ -690,12 +690,6 @@ namespace AZ::ShaderCompiler
         TypeClass typeClass = varInfo.GetTypeClass();
         assert(typeClass != TypeClass::Alias);
 
-        string errorMessage;
-        if (!m_unboundedArraysValidator.CheckFieldCanBeAddedToSrg(isUnboundedArray, srgUid, srgInfo, varUid, varInfo, typeClass, &errorMessage))
-        {
-            ThrowAzslcOrchestratorException(ORCHESTRATOR_UNBOUNDED_RESOURCE_ISSUE, ctx->start, errorMessage);
-        }
-
         if (typeClass == TypeClass::ConstantBuffer)
         {
             srgInfo.m_CBs.push_back(varUid);

--- a/src/AzslcSemanticOrchestrator.h
+++ b/src/AzslcSemanticOrchestrator.h
@@ -9,7 +9,6 @@
 
 #include "AzslcScopeTracker.h"
 #include "PreprocessorLineDirectiveFinder.h"
-#include "AzslcUnboundedArraysValidator.h"
 
 namespace AZ::ShaderCompiler
 {
@@ -423,7 +422,6 @@ namespace AZ::ShaderCompiler
         ScopeTracker*     m_scope;
         azslLexer*        m_lexer;
         PreprocessorLineDirectiveFinder* m_preprocessorLineDirectiveFinder;
-        UnboundedArraysValidator m_unboundedArraysValidator;
 
         //! cached property informing of the presence of at least one input attachment use.
         bool              m_subpassInputSeen = false;

--- a/tests/Samples/UnboundedArrays2.azsl_manual
+++ b/tests/Samples/UnboundedArrays2.azsl_manual
@@ -1,0 +1,24 @@
+ShaderResourceGroupSemantic slot1
+{
+    FrequencyId = 1;
+};
+
+struct MyStruct
+{
+    float4 m_a;
+    float4 m_b;
+};
+
+
+ShaderResourceGroup SRG1 : slot1
+{
+
+    Texture2D<float4>        m_texSRVa[];      // t0+, space1000
+    Texture2D<float4>        m_texSRVb[];      // t0+, space1001
+    RWTexture2D<float4>      m_texUAVa[];      // u0+, space1002
+    RWTexture2D<float4>      m_texUAVb[];      // u0+, space1003
+    Sampler                  m_samplera[];     // s0+, space1004
+    Sampler                  m_samplerb[];     // s0+, space1005
+    ConstantBuffer<MyStruct> m_structArraya[]; // b0+, space1006
+    ConstantBuffer<MyStruct> m_structArrayb[]; // b0+, space1007
+};


### PR DESCRIPTION
DX12 binding semantics assign a register to each binding in an array and
do not permit overlap. Spaces act as a "namespace" to permit multiple
unbounded arrays to be present in a shader. Instead of restricting
unbounded array use within an SRG, this change modifies the space
assignment strategy. Unbounded arrays (on platforms that require it,
DX12 in this case) are designated a unique space, starting from 1000 and
counting up. This "spill space" is orthogonal to the space assignment
corresponding with the SRG frequency.