### PR TITLE
Added some error checking for the --namespace command line option.

### DIFF
--- a/src/AzslcIntermediateRepresentation.h
+++ b/src/AzslcIntermediateRepresentation.h
@@ -136,8 +136,14 @@ namespace AZ::ShaderCompiler
             return (m_metaData.m_attributeNamespaceFilters.find(attr) != m_metaData.m_attributeNamespaceFilters.end());
         }
 
-        void AddAttributeNamespaceFilter(string_view attr)
+        void AddAttributeNamespaceFilter(const string& attr)
         {
+            std::regex validNamespace(R"__([a-zA-Z_]+)__");
+            if (!std::regex_match(attr, validNamespace))
+            {
+                throw std::runtime_error("Invalid namespace '" + attr + "'");
+            }
+
             m_metaData.m_attributeNamespaceFilters.emplace(attr);
         }
 

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -341,7 +341,7 @@ int main(int argc, const char* argv[])
     cli.add_flag("--pack-opengl", packOpenGL, "Pack buffers using strict OpenGL packing rules (Vector-strict std140 for uniforms and std430 for storage buffers).");
 
     std::vector<std::string> namespaces;
-    cli.add_option("--namespace", namespaces, "The list of comma-separated namespaces (no whitespace) indicates which attribute namespaces are active.");
+    cli.add_option("--namespace", namespaces, "Activate an attribute namespace. May be used multiple times to activate multiple namespaces.");
 
     bool ia = false;
     cli.add_flag("--ia", ia, "Output a list of vs entries with their Input Assembler layouts *and* a list of CS entries and their numthreads.");

--- a/tests/Advanced/multiple-attribute-namespaces.azsl
+++ b/tests/Advanced/multiple-attribute-namespaces.azsl
@@ -1,0 +1,9 @@
+ 
+[[mt::foo]] 
+struct VSInput {
+  [[vk::location(0)]] 
+  float4 pos : POSITION;
+
+  [[vk::location(1)]] 
+  float3 norm : NORMAL;
+};

--- a/tests/Advanced/multiple-attribute-namespaces.py
+++ b/tests/Advanced/multiple-attribute-namespaces.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import sys
+import os
+sys.path.append("..")
+from clr import *
+import testfuncs
+import testhelper
+
+'''
+Validates having multiple attribute namespaces in the same file.
+'''
+
+
+result = 0  # to define for sub-tests
+resultFailed = 0
+
+def doTests(compiler, silent, azdxcpath):
+    global result
+    global resultFailed
+
+    # Working directory should have been set to this script's directory by the calling parent
+    # You can get it once doTests() is called, but not during initialization of the module,
+    #  because at that time it will still be set to the working directory of the calling script
+    workDir = os.getcwd()
+
+    if testhelper.verifyEmissionPattern("multiple-attribute-namespaces.azsl", "multiple-attribute-namespaces.txt", compiler, silent, ["--namespace=mt", "--namespace=vk"]):
+        result += 1
+    else:
+        resultFailed += 1
+
+    if testhelper.compileAndExpectError("multiple-attribute-namespaces.azsl", compiler, silent, ["--namespace=mt,vk"]):
+        result += 1
+    else:
+        resultFailed += 1
+        
+    if testhelper.compileAndExpectError("multiple-attribute-namespaces.azsl", compiler, silent, ["--namespace=mt&vk"]):
+        result += 1
+    else:
+        resultFailed += 1
+
+if __name__ == "__main__":
+    print ("please call from testapp.py")

--- a/tests/Advanced/multiple-attribute-namespaces.txt
+++ b/tests/Advanced/multiple-attribute-namespaces.txt
@@ -1,0 +1,8 @@
+ 
+"[[ mt :: foo ]]            "
+"struct VSInput         "
+"[[ vk :: location ( 0 ) ]]    "
+"float4 pos : POSITION ; "
+"[[ vk :: location ( 1 ) ]]    "
+"float3 norm : NORMAL ;  "
+

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -56,6 +56,7 @@ def verifyEmissionPattern(azslFile, patternsFileName, compilerPath, silent, argL
     Compiles @azslFile and validates all the predicates in @patternsFileName.
     """
     if not os.path.exists(patternsFileName):
+        print ("Pattern file not found: " + patternsFileName)
         return False
     arg = []
     with io.open(patternsFileName, "r", encoding="latin-1") as f:


### PR DESCRIPTION
Before if you try and list the namespaces like "--namespace=mt,vk" it will fail, activating one namespace called "mt,vk". Multiple namespaces have to be like "--namespace=mt --namespace=vk".
Added a new automated test to verify this.

Relates to https://github.com/o3de/o3de/issues/8162

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>