### PR TITLE
Fix usage of `exportKeywords.py` by using the correct flags

### DIFF
--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -398,7 +398,7 @@ int main(int argc, const char* argv[])
     cli.add_flag("-r", visitRecursively, "(Option of --visitsym) Visit recursively.");
 
     bool listPredefined = false;
-    cli.add_flag("--listpredefined", "Output a list of all predefined types in AZSLang.");
+    cli.add_flag("--listpredefined", listPredefined, "Output a list of all predefined types in AZSLang.");
 
     int maxSpaces = std::numeric_limits<int>::max();
     auto maxSpacesOpt = cli.add_option("--max-spaces", maxSpaces, "Will choose register spaces that do not extend past this limit.");

--- a/tests/testfuncs.py
+++ b/tests/testfuncs.py
@@ -145,10 +145,9 @@ def buildAndGetError(thefile, compilerPath, silent, extraArgs):
 def dumpKeywords(compilerPath):
     '''returns tuple: (categorized-tokens-in-algebraic-form, ok-bool)'''
     import clr
-    silent = False
-    stdout, stderr, code = launchCompiler(compilerPath, ["--listpredefined"], silent)
+    stdout, stderr, code = launchCompiler(compilerPath, ["--listpredefined"], False)
     if code != 0:
-        if not silent: print (clr.fg.RED + "compilation failed" + clr.style.RESET_ALL)
+        print (clr.fg.RED + "compilation failed" + clr.style.RESET_ALL)
         return (None, False)
     else:
         tokens = parseYaml(stdout)

--- a/tests/testfuncs.py
+++ b/tests/testfuncs.py
@@ -145,7 +145,8 @@ def buildAndGetError(thefile, compilerPath, silent, extraArgs):
 def dumpKeywords(compilerPath):
     '''returns tuple: (categorized-tokens-in-algebraic-form, ok-bool)'''
     import clr
-    stdout, stderr, code = launchCompiler(compilerPath, ["--listpredefined"], False)
+    silent = False
+    stdout, stderr, code = launchCompiler(compilerPath, ["--listpredefined"], silent)
     if code != 0:
         if not silent: print (clr.fg.RED + "compilation failed" + clr.style.RESET_ALL)
         return (None, False)


### PR DESCRIPTION
Signed-off-by: Martin Winter <martin.winter@huawei.com>

The `exportKeywords.py` script can be used to generate a list of predefined types. The current state did not have a variable set (`silent` was not set but `False` passed directly) and the argument parser did not properly receive the `--listpredefined` flag, hence always crashed.