### PR TITLE
improve test scripts

### DIFF
--- a/tests/builder.py
+++ b/tests/builder.py
@@ -39,7 +39,7 @@ def findDXC(silent):
         if not silent: print (fg.YELLOW+ style.BRIGHT+ "Will only test dxc.exe on Windows 10."+ style.RESET_ALL)
         return None
 
-    windowsKitsDir = "C:/Program Files (x86)/Windows Kits/10/bin"
+    windowsKitsDir = os.path.expandvars("%ProgramFiles(x86)%/Windows Kits/10/bin")
     if not os.path.isdir(windowsKitsDir):
         if not silent: print (fg.YELLOW+ style.BRIGHT+ "Expected {}, but did not find it.".format(windowsKitsDir)+ style.RESET_ALL)
         return None
@@ -54,7 +54,7 @@ def findDXC(silent):
         return None
 
     return dxcLocations[0]
-    
+
 '''Returns the path to the Spirv-Cross compiler, or None if it can't be found'''
 def findSpirvCross(spirvCrossPath, silent):
     if not os.path.isdir(spirvCrossPath):
@@ -126,7 +126,7 @@ def buildDXC(thefile, compilerPath, silent, extraIncList, azslcArgs, dxcArgs, az
     if os.path.exists(sbinPS):  os.remove(sbinPS)
 
     stdout, ok = testfuncs.buildAndGet(thefile, compilerPath, silent, azslcArgs)
-    if not ok: 
+    if not ok:
         if not silent: print (fg.RED+ style.BRIGHT+ "Failed to generate .hlsl file with AZSLc."+ style.RESET_ALL)
         return buildFailed
 
@@ -134,7 +134,7 @@ def buildDXC(thefile, compilerPath, silent, extraIncList, azslcArgs, dxcArgs, az
     f = open(codeOut, "wb+")
     for incFile in extraIncList:
         fInFullname = os.path.join(os.path.dirname(thefile), incFile)
-        if not os.path.exists(fInFullname): 
+        if not os.path.exists(fInFullname):
             if not silent: print (fg.RED+ style.BRIGHT+ "Include file {} doesn't exist!".format(fInFullname)+ style.RESET_ALL)
             return buildFailed
         fIn = open(fInFullname, "rb")
@@ -142,7 +142,7 @@ def buildDXC(thefile, compilerPath, silent, extraIncList, azslcArgs, dxcArgs, az
         fIn.close()
     f.write(stdout)
     f.close()
-        
+
     dxcCompileArgs = [dxcPath, "-T", "vs_6_2", "-E", "MainVS"] + dxcArgs + ["-Fo", sbinVS, codeOut]
     process = subprocess.Popen(dxcCompileArgs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = process.communicate()
@@ -150,7 +150,7 @@ def buildDXC(thefile, compilerPath, silent, extraIncList, azslcArgs, dxcArgs, az
     if not os.path.exists(sbinVS):
         if not silent: print (fg.RED + style.BRIGHT + "Failed to compile MainVS with dxc.exe(for "+OutFormat+")." + style.RESET_ALL)
         return buildFailed
-    
+
     dxcCompileArgs = [dxcPath, "-T", "ps_6_2", "-E", "MainPS"] + dxcArgs + ["-Fo", sbinPS, codeOut]
     process = subprocess.Popen(dxcCompileArgs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = process.communicate()
@@ -172,12 +172,12 @@ def buildDXCCompute(thefile, compilerPath, silent, extraIncList, azslcArgs, dxcA
     inFile, inFileExt = os.path.splitext(thefile)
     codeOut  = inFile + ".hlsl"
     sbinCS   = inFile + "CS." + OutFormat
-    
+
     if os.path.exists(codeOut): os.remove(codeOut)
     if os.path.exists(sbinCS):  os.remove(sbinCS)
 
     stdout, ok = testfuncs.buildAndGet(thefile, compilerPath, silent, azslcArgs)
-    if not ok: 
+    if not ok:
         if not silent: print (fg.RED+ style.BRIGHT+ "Failed to generate .hlsl file with AZSLc."+ style.RESET_ALL)
         return buildFailed
 
@@ -185,7 +185,7 @@ def buildDXCCompute(thefile, compilerPath, silent, extraIncList, azslcArgs, dxcA
     f = open(codeOut, "wb+")
     for incFile in extraIncList:
         fInFullname = os.path.join(os.path.dirname(thefile), incFile)
-        if not os.path.exists(fInFullname): 
+        if not os.path.exists(fInFullname):
             if not silent: print (fg.RED+ style.BRIGHT+ "Include file {} doesn't exist!".format(fInFullname)+ style.RESET_ALL)
             return buildFailed
         fIn = io.open(fInFullname, "r", encoding="latin-1")
@@ -201,6 +201,6 @@ def buildDXCCompute(thefile, compilerPath, silent, extraIncList, azslcArgs, dxcA
     if not os.path.exists(sbinCS):
         if not silent: print (fg.RED+ style.BRIGHT+ "Failed to compile MainCS with dxc.exe."+ style.RESET_ALL)
         return buildFailed
-    
+
     if not silent: print (fg.GREEN+style.BRIGHT+ "["+thefile+"."+ OutFormat + "]" + style.RESET_ALL)
     return buildSucceeded

--- a/tests/testapp.py
+++ b/tests/testapp.py
@@ -23,7 +23,7 @@ class testResult:
         self.numPass = p
         self.numTodo = t
         self.numFail = f
-        self.numEC = m
+        self.numEC = m   #EC = error code
 
     def add(self, other):
         self.numPass += other.numPass
@@ -185,6 +185,13 @@ def runAll(testsRoot, paths, compiler, verboseLevel, az3rdParty):
 
 if __name__ == "__main__":
     os.system('') # activate VT100 mode for windows console
+
+    try:
+        import yaml
+    except ImportError as err:
+        print ( fg.YELLOW + style.BRIGHT + "It seems your python environment lacks pyyaml. Run first through project-root's \"test.and.py\" (or pip install it)" + style.RESET_ALL )
+        if input("Continue (may result in false failures)? y/n:").lower() != "y":
+            exit(0)
 
     parser = ArgumentParser()
     parser.add_argument(

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -42,7 +42,7 @@ def found(needle, haystack):
         lastEnd = matchObject.end()
         return True
     return False
-    
+
 # pars the argument mentioned in the shader source file Ex : Cmdargs: --namespace=vk   or Cmdargs: ['--unique-idx', '--root-sig', '--root-const', '0']
 def parse_strlist(sl):
     clean = re.sub("[\[\],\s]","",sl)
@@ -89,7 +89,7 @@ def verifyEmissionPattern(azslFile, patternsFileName, compilerPath, silent, argL
         reset()
         ok = testfuncs.verifyAllPredicates(predicates, shaderCode, silent)
     return ok
-    
+
 # read the output of the compiler and tries to match some regex on it
 # to verify that the output looks like what we expect.
 def verifyEmissionPatterns(thefile, compilerPath, silent, argList):
@@ -104,19 +104,19 @@ def verifyEmissionPatterns(thefile, compilerPath, silent, argList):
         patterFileName = file
         if not verifyEmissionPattern(thefile, patterFileName, compilerPath, silent, argList):
             localFailList.append(patterFileName)
-        else: 
+        else:
             result = result + 1
     if len(localFailList) > 0:
         failList.extend(localFailList)
         return 0
     else:
         return result
-        
+
 def printFailedTestList(silent):
     global failList
     if not silent and len(failList) > 0:
         print(style.BRIGHT + fg.RED + "failed files: " + fg.WHITE + str(failList) + style.RESET_ALL)
-        
+
     failList = [] # since the module is imported for other platforms too, reset the list
 
 def compileAndExpectError(thefile, compilerPath, silent, argList):


### PR DESCRIPTION
addresses https://github.com/o3de/o3de-azslc/issues/46
+ use environment variable for program files
+ verify early that pyyaml isn't missing. this causes 20 fails.
+ trim whitespace