### PR TITLE
Fix for ambiguous Streamable operator overload error on gcc

### DIFF
--- a/src/AzslcUtils.h
+++ b/src/AzslcUtils.h
@@ -266,6 +266,11 @@ namespace AZ::ShaderCompiler
         return out << ToLower(StorageFlag::ToStr(sf));
     }
 
+    inline Streamable& operator << (Streamable& out, StorageFlag sf)
+    {
+        return out << sf.m_value;
+    }
+
     using Modifiers = Flag<StorageFlag>;
     struct TypeQualifiers
     {


### PR DESCRIPTION
Change add's an explicit overload for `operator << (Streamable, StorageFlag)`

Error was 
```
                from /home/breja/github/AZSLc/src/AzslcEmitter.cpp:9:
/home/breja/github/AZSLc/src/GenericUtils.h: In instantiation of ‘std::string AZ::Join(Iter, Iter, std::string_view) [with Iter = __gnu_cxx::__normal_iterator<AZ::ShaderCompiler::StorageFlag*, std::vector<AZ::ShaderCompiler::StorageFlag> >; std::string = std::__cxx11::basic_string<char>; std::string_view = std::basic_string_view<char>]’:
/home/breja/github/AZSLc/src/AzslcUtils.h:281:36:   required from here
/home/breja/github/AZSLc/src/GenericUtils.h:257:14: error: ambiguous overload for ‘operator<<’ (operand types are ‘AZ::Streamable’ and ‘AZ::ShaderCompiler::StorageFlag’)
  257 |         wrap << *begin;
      |         ~~~~~^~~~~~~~~
In file included from /home/breja/github/AZSLc/src/GenericUtils.h:13,
                 from /home/breja/github/AZSLc/src/AzslcSymbolTable.h:10,
                 from /home/breja/github/AZSLc/src/AzslcSymbolAggregator.h:10,
                 from /home/breja/github/AZSLc/src/AzslcScopeTracker.h:10,
                 from /home/breja/github/AZSLc/src/AzslcSemanticOrchestrator.h:10,
                 from /home/breja/github/AZSLc/src/AzslcIntermediateRepresentation.h:10,
                 from /home/breja/github/AZSLc/src/AzslcListener.h:10,
                 from /home/breja/github/AZSLc/src/AzslcBackend.h:10,
                 from /home/breja/github/AZSLc/src/AzslcEmitter.h:10,
                 from /home/breja/github/AZSLc/src/AzslcEmitter.cpp:9:
/home/breja/github/AZSLc/src/StreamableInterface.h:20:29: note: candidate: ‘virtual AZ::Streamable& AZ::Streamable::operator<<(char)’
   20 |         virtual Streamable& operator<<(char) = 0;    // template virtual method are forbidden in C++, so manual listing :(
      |                             ^~~~~~~~
/home/breja/github/AZSLc/src/StreamableInterface.h:22:29: note: candidate: ‘virtual AZ::Streamable& AZ::Streamable::operator<<(double)’
   22 |         virtual Streamable& operator<<(double) = 0;
      |                             ^~~~~~~~
/home/breja/github/AZSLc/src/StreamableInterface.h:23:29: note: candidate: ‘virtual AZ::Streamable& AZ::Streamable::operator<<(int64_t)’
   23 |         virtual Streamable& operator<<(int64_t) = 0;
      |                             ^~~~~~~~
/home/breja/github/AZSLc/src/StreamableInterface.h:24:29: note: candidate: ‘virtual AZ::Streamable& AZ::Streamable::operator<<(uint64_t)’
   24 |         virtual Streamable& operator<<(uint64_t) = 0;
      |                             ^~~~~~~~
/home/breja/github/AZSLc/src/StreamableInterface.h:25:29: note: candidate: ‘virtual AZ::Streamable& AZ::Streamable::operator<<(int32_t)’
   25 |         virtual Streamable& operator<<(int32_t) = 0;
      |                             ^~~~~~~~
/home/breja/github/AZSLc/src/StreamableInterface.h:26:29: note: candidate: ‘virtual AZ::Streamable& AZ::Streamable::operator<<(uint32_t)’
   26 |         virtual Streamable& operator<<(uint32_t) = 0;
      |                             ^~~~~~~~
/home/breja/github/AZSLc/src/StreamableInterface.h:28:29: note: candidate: ‘virtual AZ::Streamable& AZ::Streamable::operator<<(bool)’
   28 |         virtual Streamable& operator<<(bool) = 0;
      |                             ^~~~~~~~
In file included from /home/breja/github/AZSLc/src/AzslcTypes.h:10,
                 from /home/breja/github/AZSLc/src/AzslcKindInfo.h:10,
                 from /home/breja/github/AZSLc/src/AzslcSymbolTable.h:11,
                 from /home/breja/github/AZSLc/src/AzslcSymbolAggregator.h:10,
                 from /home/breja/github/AZSLc/src/AzslcScopeTracker.h:10,
                 from /home/breja/github/AZSLc/src/AzslcSemanticOrchestrator.h:10,
                 from /home/breja/github/AZSLc/src/AzslcIntermediateRepresentation.h:10,
                 from /home/breja/github/AZSLc/src/AzslcListener.h:10,
                 from /home/breja/github/AZSLc/src/AzslcBackend.h:10,
                 from /home/breja/github/AZSLc/src/AzslcEmitter.h:10,
                 from /home/breja/github/AZSLc/src/AzslcEmitter.cpp:9:
/home/breja/github/AZSLc/src/AzslcUtils.h:264:24: note: candidate: ‘AZ::Streamable& AZ::ShaderCompiler::operator<<(AZ::Streamable&, AZ::ShaderCompiler::StorageFlag::EnumType)’
  264 |     inline Streamable& operator << (Streamable& out, StorageFlag::EnumType sf)
      |                        ^~~~~~~~
/home/breja/github/AZSLc/src/AzslcEmitter.cpp:47:17: note: candidate: ‘AZ::Streamable& AZ::ShaderCompiler::operator<<(AZ::Streamable&, const AZ::ShaderCompiler::AttributeInfo::Argument&)’
   47 |     Streamable& operator << (Streamable& out, const AttributeInfo::Argument& arg)
      |                 ^~~~~~~~
```

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>