### PR TITLE
Fix pad_to doesn't silence error 131

### DIFF
--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,7 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "9"  // last change: resource unbounded arrays support
+#define AZSLC_REVISION "10"  // last change: fix for "[[pad_to()]] doesn't silence error IR 131 potential alignment issues"
 
 
 namespace AZ::ShaderCompiler

--- a/src/AzslcSymbolTable.cpp
+++ b/src/AzslcSymbolTable.cpp
@@ -27,7 +27,7 @@ namespace AZ::ShaderCompiler
         return iter == m_symbols.cend() ? nullptr : &(*iter);
     }
 
-    bool SymbolTable::DeleteIdentifier(IdentifierUID name)
+    bool SymbolTable::DeleteIdentifier(const IdentifierUID& name)
     {
         auto iter = m_symbols.find(name);
         bool found = iter != m_symbols.end();
@@ -38,6 +38,17 @@ namespace AZ::ShaderCompiler
             m_order.erase(std::remove(m_order.begin(), m_order.end(), name), m_order.end());
         }
         return found;
+    }
+
+    void SymbolTable::MigrateOrder(const IdentifierUID& symbol, const IdentifierUID& before)
+    {
+        // For use in PadToAttributeMutator::InsertPaddingVariables::createVariableInSymbolTable
+        auto beforeSymbolIter = std::find(m_order.begin(), m_order.end(), before);
+        if (beforeSymbolIter != m_order.end())
+        {
+            m_order.erase(std::remove(m_order.begin(), m_order.end(), symbol), m_order.end());
+            m_order.insert(beforeSymbolIter, symbol);
+        }
     }
 
     IdAndKind& SymbolTable::AddIdentifier(QualifiedNameView symbol, Kind kind, optional<size_t> lineNumber /*= none*/)
@@ -56,13 +67,6 @@ namespace AZ::ShaderCompiler
                                      ConcatString("ODR (One Definition Rule) violation. Redeclaration of ",
                                                   Kind::ToStr(kind), " ", ExtractLeaf(symbol), " in ", LevelUp(symbol), "  ",
                                                   GetFirstSeenLineMessage(fetchedIdIt->second), "\n"));
-
-                // Since a redeclaration becomes the new identity, we must erase its old appearance in the order list:
-                //  (motivated by the requirement that if we emit a function body, it can't be at the site of its first declaration.
-                //   since the definition is the only guaranteed place where the body will not refer to yet-undeclared symbols)
-                //  As a bonus, it also cleans-up the --dumpsym option which had duplicated output.
-                //  (reinstates the invariant of unicity of apparition)
-                m_order.erase(std::remove(m_order.begin(), m_order.end(), fetchedIdIt->first), m_order.end());
             }
         }
         else

--- a/src/AzslcSymbolTable.h
+++ b/src/AzslcSymbolTable.h
@@ -23,13 +23,17 @@ namespace AZ::ShaderCompiler
 
         auto GetIdAndKindInfo(QualifiedNameView symbol) const -> const IdAndKind*;
 
-        /// Register a fresh entry in the symbol map. No KindInfo filled up, the client must do it.
-        /// Will return a reference to the newly inserted data.
-        /// Will throw in case of ODR violation.
+        //! Register a fresh entry in the symbol map. No KindInfo filled up, the client must do it.
+        //! Will return a reference to the newly inserted data.
+        //! Will throw in case of ODR violation.
         auto AddIdentifier(QualifiedNameView symbol, Kind kind, optional<size_t> lineNumber = none) -> IdAndKind&;
 
-        /// Return true if found and deleted
-        bool DeleteIdentifier(IdentifierUID name);
+        //! Can be used to hack the position of a symbol added late, after the phase of semantic check.
+        //! Typically hidden symbols added by the compiler such as implicit structs or padding fields.
+        void MigrateOrder(const IdentifierUID& symbol, const IdentifierUID& before);
+
+        //! Return true if found and deleted
+        bool DeleteIdentifier(const IdentifierUID& name);
 
         // [GFX TODO]2: use densemap/oahm to avoid fragmentation (depends on [Task 5])
         IdToKindMap           m_symbols;   // declarations of any kind and attached information (unordered bag, but O(1+) lookup)

--- a/src/PadToAttributeMutator.cpp
+++ b/src/PadToAttributeMutator.cpp
@@ -477,7 +477,7 @@ namespace AZ::ShaderCompiler
         {
             const auto alignedOffset = Packing::AlignUp(startingOffset, 16);
             const auto deltaBytes = alignedOffset - startingOffset;
-            if (deltaBytes < numBytesToAdd)
+            if (deltaBytes < numBytesToAdd && deltaBytes != 0)
             {
                 string typeName = getFloatTypeNameOfSize(deltaBytes);
                 auto variableName = FormatString("__pad_at%u", startingOffset);
@@ -489,6 +489,7 @@ namespace AZ::ShaderCompiler
                 else
                 {
                     classInfo->InsertBefore(newVarUid, Kind::Variable, insertBeforeThisUid);
+                    m_ir.m_symbols.m_elastic.MigrateOrder(newVarUid, insertBeforeThisUid);
                 }
                 numAddedVariables++;
                 numBytesToAdd -= deltaBytes;
@@ -510,6 +511,7 @@ namespace AZ::ShaderCompiler
                 else
                 {
                     classInfo->InsertBefore(newVarUid, Kind::Variable, insertBeforeThisUid);
+                    m_ir.m_symbols.m_elastic.MigrateOrder(newVarUid, insertBeforeThisUid);
                 }
                 numAddedVariables++;
                 numBytesToAdd -= (numFloat4s << 4);
@@ -530,6 +532,7 @@ namespace AZ::ShaderCompiler
             else
             {
                 classInfo->InsertBefore(newVarUid, Kind::Variable, insertBeforeThisUid);
+                m_ir.m_symbols.m_elastic.MigrateOrder(newVarUid, insertBeforeThisUid);
             }
             numAddedVariables++;
         }

--- a/tests/Emission/pad-antiregression-float2x2srgcst.azsl
+++ b/tests/Emission/pad-antiregression-float2x2srgcst.azsl
@@ -1,0 +1,7 @@
+ShaderResourceGroupSemantic ExampleBinding { FrequencyId = 0; };
+ShaderResourceGroup ExampleSRG : ExampleBinding
+{
+    float2x2 mat;
+    [[pad_to(36)]]
+    bool b;
+};

--- a/tests/Emission/pad-antiregression-float2x2srgcst.txt
+++ b/tests/Emission/pad-antiregression-float2x2srgcst.txt
@@ -1,0 +1,4 @@
+"float2x2 ExampleSRG_mat ;"
+"float4 ExampleSRG___pad_at16 [ 1 ] ;"
+"float ExampleSRG___pad_at32 ;"
+"bool ExampleSRG_b ;"

--- a/tests/Emission/pad-antiregression-float2x2srgcst.txt
+++ b/tests/Emission/pad-antiregression-float2x2srgcst.txt
@@ -1,4 +1,4 @@
 "float2x2 ExampleSRG_mat ;"
-"float4 ExampleSRG___pad_at16 [ 1 ] ;"
+"float4 ExampleSRG___pad_at16 [1] ;"
 "float ExampleSRG___pad_at32 ;"
 "bool ExampleSRG_b ;"

--- a/tests/Semantic/srg-pad.azsl
+++ b/tests/Semantic/srg-pad.azsl
@@ -1,0 +1,7 @@
+ShaderResourceGroupSemantic ExampleBinding { FrequencyId = 0; };
+ShaderResourceGroup ExampleSRG : ExampleBinding
+{
+    float3x3 mat;
+    [[pad_to(44)]]
+    bool b;
+};


### PR DESCRIPTION
In case of such a program as input:

```
ShaderResourceGroupSemantic ExampleBinding { FrequencyId = 0; };
ShaderResourceGroup ExampleSRG : ExampleBinding
{
    float3x3 mat;
    bool b;
};
```

We get the result

> IR error #131: Detected potential alignment issues related with DXC flag '-fvk-use-dx-layout'.
> Alternatively you can use the option '--no-alignment-validation' to void this error
> - A 'float2' variable should be added before the variable 'b'

It seems natural that we can either follow the recommendation, or use the `[[pad_to()]]` attribute as such:

```
    float3x3 mat;
    [[pad_to(44)]]
    bool b;
```

Doing so in conjunction with --no-alignment-validation did result in a float2 being inserted so the error message should go away. But it didn't. This PR fixes that.

Secondly, there was a crash in case of this input:
```
    float2x2 mat;
    [[pad_to(36)]]
    bool b;
```