### PR TITLE
little fix: `static` in SRG caused double emission

### DIFF
--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,7 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "9"  // last change: resource unbounded arrays support
+#define AZSLC_REVISION "13"  // last change: fix of static samplers in SRG get double emission
 
 
 namespace AZ::ShaderCompiler

--- a/tests/Emission/double-emission-static-sampler-antiregress.azsl
+++ b/tests/Emission/double-emission-static-sampler-antiregress.azsl
@@ -1,0 +1,15 @@
+ShaderResourceGroupSemantic slot1
+{
+    FrequencyId = 1;
+};
+
+ShaderResourceGroup S : slot1
+{
+    TextureCube<float4> t;
+    static sampler grass {ComparisonFunc = Never;};
+};
+
+float4 MainPS(float2 uv : TEXCOORD0) : SV_Target0
+{
+    return S::t.Sample(S::grass, float3(1,0,0));
+}

--- a/tests/Emission/double-emission-static-sampler-antiregress.txt
+++ b/tests/Emission/double-emission-static-sampler-antiregress.txt
@@ -1,0 +1,5 @@
+" TextureCube < float4 > S_t : register ( t0 , space0 ) ; "
+^"SamplerComparisonState S_grass : register ( s0 , space0 ) ;"
+"static sampler S_grass"
+"ComparisonFunc = Never ;"
+"float4 MainPS"


### PR DESCRIPTION
prohibit static SRG members emission, because static members don't participate in the resources, they are normal local variables. they will be taken care of by their normal emission path.

+ add possiblity to test for the ABSCENCE of code in emssion tests using ^ character at beginning of line (as for [^] in regex lang).

input:
```c
ShaderResourceGroup S : slot1
{
    static Texture2D t;
};
```
result before:
```c
static Texture2D S_t : register(t0, space0);
static Texture2D S_t;
```
result now:
```c
static Texture2D S_t;
```