### PR TITLE
fix a runtime error in function semantic registration

### DIFF
--- a/src/AzslcKindInfo.h
+++ b/src/AzslcKindInfo.h
@@ -395,7 +395,7 @@ namespace AZ::ShaderCompiler
         AstEnumeratorDecl*         m_declNodeEnum = nullptr;
         UnqualifiedName            m_identifier;
         bool                       m_srgMember = false;
-        bool                       m_isPublic = true;
+        bool                       m_isPublic = true;  // this isn't class access visibility, this is for generated fields
         ConstNumericVal            m_constVal;   // (attempted folded) initializer value for simple scalars
         optional<SamplerStateDesc> m_samplerState;
         ExtendedTypeInfo           m_typeInfoExt;
@@ -644,6 +644,14 @@ namespace AZ::ShaderCompiler
         unordered_map<size_t, IdentifierUID> m_argCounts; //!< number of parameters as keys to a unique candidate that has this count.
     };
 
+    //! This is a small state machine for function registration step tracking (e.g. decl, decl, def)
+    enum FunctionMultiForwards
+    {
+        FMF_None,  // no redundant declarators
+        FMF_FwdDeclRedundancy,  // at least one redundant declarators (warning has been produced)
+        FMF_SeenDef  // now encountered definition block
+    };
+
     struct FunctionInfo
     {
         //! tells if the FunctionInfo object hasn't been initialized
@@ -782,6 +790,7 @@ namespace AZ::ShaderCompiler
         bool                      m_isVirtual    = false;     //!< is a method from an interface
         vector< IdentifierUID >   m_overrides;                //!< list of implementing functions in child classes
         optional< IdentifierUID > m_base;   //!< points to the overridden function in the base interface, if applies. only supports one base
+        FunctionMultiForwards     m_multiFwds    = FMF_None;  //!< presence of redundant prototype-only declarations
         struct Parameter
         {
             IdentifierUID m_varId;

--- a/src/AzslcListener.cpp
+++ b/src/AzslcListener.cpp
@@ -221,13 +221,17 @@ namespace AZ::ShaderCompiler
 
     void SemaCheckListener::exitFunctionParam(azslParser::FunctionParamContext* ctx)
     {   // we use the exit rule to let the time to inlined-UDT-decl to get registered through the type rule visit first.
-        if (!ctx->Name)
+        auto& funcInfo = m_ir->m_sema.GetCurrentScopeSubInfoAs<FunctionInfo>();
+        if (funcInfo.m_multiFwds != FMF_FwdDeclRedundancy)  // when in that state, we don't accept parameter registration
         {
-            m_ir->m_sema.RegisterNamelessFunctionParameter(ctx);
-        }
-        else
-        {
-            m_ir->m_sema.RegisterVar(ctx->Name, ctx->unnamedVariableDeclarator());
+            if (!ctx->Name)
+            {
+                m_ir->m_sema.RegisterNamelessFunctionParameter(ctx);
+            }
+            else
+            {
+                m_ir->m_sema.RegisterVar(ctx->Name, ctx->unnamedVariableDeclarator());
+            }
         }
     }
 

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,8 +23,8 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "15"  // last change: add min in option value key-extracter's function for range & enum
-                    // "14"          change: [5a1b711] Fixing order of multiple unbounded arrays when unique indices are used.
+#define AZSLC_REVISION "16"  // last change: fixup runtime error with redundant function declarations
+                    // "15"          change: add min in option value key-extracter's function for range & enum
 
 namespace AZ::ShaderCompiler
 {

--- a/src/AzslcSemanticOrchestrator.cpp
+++ b/src/AzslcSemanticOrchestrator.cpp
@@ -238,8 +238,10 @@ namespace AZ::ShaderCompiler
             {
                 PrintWarning(Warn::W1, ctx->start, "ignored redundant redeclaration of function ", decoratedName,
                              ", ", GetFirstSeenLineMessage(symbol->second));
+                funcInfo->m_multiFwds = FMF_FwdDeclRedundancy;
                 return *symbol;
             }
+            funcInfo->m_multiFwds = FMF_SeenDef;
             auto originalKind = symbol->second.GetKind();
             if (originalKind != Kind::Function)  // verify that we're not transforming a lychee into a melon
             {

--- a/tests/Semantic/func-redecl-merge-regress.azsl
+++ b/tests/Semantic/func-redecl-merge-regress.azsl
@@ -1,0 +1,6 @@
+void func(int);
+void func(int);
+
+void func(int)
+{
+}

--- a/tests/Semantic/func-redecl-named-param-shouldnt-error.azsl
+++ b/tests/Semantic/func-redecl-named-param-shouldnt-error.azsl
@@ -1,0 +1,2 @@
+void func(int a);
+void func(int a);


### PR DESCRIPTION
While investigating if https://github.com/o3de/o3de-azslc/issues/37 was really fixed, I stumbled uppon remaining issues.
The fix of december https://github.com/o3de/o3de-azslc/commit/0c4eccd90108f6283a813f996e24acb4f6635364
definitely fixed a crash, but it wasn't investigated further after that. In fact in unlocked the door to at least 2 scenarios that don't finish compilation in a normal manner (fatal internal).
I added 2 tests to make sure we don't regress on those 2. And the simplest fix I could find, in the form of a mini 3 state automata in the function symbol info.

before:
case 1:
![image](https://user-images.githubusercontent.com/25970839/221200871-336a86da-7584-498e-9289-d15c567b1f45.png)
(no code output on stdout since fatal error interrupted)
case 2:
![image](https://user-images.githubusercontent.com/25970839/221200924-57b88e2f-ec9d-4d88-8108-bcfc1bc7d894.png)
(no code output, only stderr ODR message)

after:
![image](https://user-images.githubusercontent.com/25970839/221201260-e1812ff1-d8c9-4f80-b51f-28a1b4520619.png)
Same for both 2 cases.