### PR TITLE
Fix for nonsensical error message in class + option program

### DIFF
--- a/src/AzslcIntermediateRepresentation.cpp
+++ b/src/AzslcIntermediateRepresentation.cpp
@@ -719,6 +719,11 @@ namespace AZ::ShaderCompiler
         {
             const IdentifierUID uid = orderedSymbols[symbolIndex];
             KindInfo* kindInfo = GetKindInfo(uid);
+            if (IsGlobal(uid.GetName()))
+            {
+                continue; // no reason to align things in the global scope,
+                          // options and rootconstant will be align-checked through their implicit structs.
+            }
 
             // We need to keep track of the structs for which the last member is
             // a float3x3.
@@ -773,10 +778,15 @@ namespace AZ::ShaderCompiler
             // 2- a float2x2, float3x2, float4x2,
             //    float2x3, float3x3, float4x3.
             //! Helper lambda to get the previously declared variable.
-            auto getPreviousVarInfo = [&](ssize_t& startSearchSymbolIndex /*in out*/) -> VarInfo* {
+            auto getPreviousVarInfo = [&](ssize_t& startSearchSymbolIndex /*in out*/, string_view scope) -> VarInfo*
+            {
                 while (startSearchSymbolIndex >= 0)
                 {
                     const auto& prevSymbolUid = orderedSymbols[startSearchSymbolIndex];
+                    if (GetParentName(prevSymbolUid.GetName()) != scope)
+                    {
+                        return nullptr;  // we can't relate variables that don't even belong to same struct or srg
+                    }
                     KindInfo* prevKindInfo = GetKindInfo(prevSymbolUid);
                     VarInfo* prevVarInfo = prevKindInfo->GetSubAs<VarInfo>();
                     if (prevVarInfo)
@@ -789,7 +799,7 @@ namespace AZ::ShaderCompiler
             };
 
             ssize_t prevSymbolIndex = symbolIndex - 1;
-            const VarInfo* prevVarInfo = getPreviousVarInfo(prevSymbolIndex);
+            const VarInfo* prevVarInfo = getPreviousVarInfo(prevSymbolIndex, GetParentName(uid.GetName()));
             if (prevVarInfo == nullptr)
             {
                 // Nothing to do, keep going.

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,8 +23,8 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "16"  // last change: fixup runtime error with redundant function declarations
-                    // "15"          change: add min in option value key-extracter's function for range & enum
+#define AZSLC_REVISION "17"  // last change: fixup alignment check logic_error because of lack of an inter-scope check limiter.
+                    // "16"          change: fixup runtime error with redundant function declarations
 
 namespace AZ::ShaderCompiler
 {


### PR DESCRIPTION
The commit message explains the issue and the fix.

Input program effect on code in debug, point of failure:
![image](https://user-images.githubusercontent.com/25970839/227714373-2d74b027-e6b0-4959-8de5-4b8736f25f58.png)

Test done:
- test suite run, all green.
- one new test added for regression prevention
- manual verification that feature is still working in the most classic expected case (both in v 1.8.16 and new 1.8.17)
![image](https://user-images.githubusercontent.com/25970839/227714425-6a676f9e-c038-4969-8cf7-e91dcb024dee.png)

