### PR TITLE
Auto option ranks

### DIFF
--- a/src/AzslcBackend.cpp
+++ b/src/AzslcBackend.cpp
@@ -449,6 +449,7 @@ namespace AZ::ShaderCompiler
             // We reserve the right to change it in the future so we make it explicit attribute here
             shaderOption["order"] = optionOrder;
             optionOrder++;
+            shaderOption["costImpact"] = varInfo->m_estimatedCostImpact;
 
             bool isUdt = IsUserDefined(varInfo->GetTypeClass());
             assert(isUdt || IsPredefinedType(varInfo->GetTypeClass()));

--- a/src/AzslcEmitter.cpp
+++ b/src/AzslcEmitter.cpp
@@ -1277,7 +1277,6 @@ namespace AZ::ShaderCompiler
         const ICodeEmissionMutator* codeMutator = m_codeMutator;
 
         ssize_t ii = interval.a;
-        bool wasInPreprocessorDirective = false;  // record a state to detect exit of directives, because they need to reside on their own lines
         while (ii <= interval.b)
         {
             auto* token = GetNextToken(ii /*inout*/);

--- a/src/AzslcIntermediateRepresentation.cpp
+++ b/src/AzslcIntermediateRepresentation.cpp
@@ -332,7 +332,6 @@ namespace AZ::ShaderCompiler
                 cout << "  storage: " << sub.m_typeInfoExt.m_qualifiers.GetDisplayName() << "\n";
                 cout << "  array dim: \"" << sub.m_typeInfoExt.m_arrayDims.ToString() << "\"\n";
                 cout << "  has sampler state: " << (sub.m_samplerState ? "yes\n" : "no\n");
-                cout << "\n";
                 if (!holds_alternative<monostate>(sub.m_constVal))
                 {
                     cout << "  val: " << ExtractValueAsInt64(sub.m_constVal) << "\n";
@@ -950,30 +949,4 @@ namespace AZ::ShaderCompiler
         }
         return memberList[memberList.size() - 1];
     }
-
-    void IntermediateRepresentation::AnalyzeOptionRanks()
-    {
-        // loop over variables
-        for (auto& [uid, varInfo, kindInfo] : m_symbols.GetOrderedSymbolsOfSubType_3<VarInfo>())
-        {
-            // only options
-            if (varInfo->CheckHasStorageFlag(StorageFlag::Option))
-            {
-                int impactScore = 0;
-                // loop over appearances over the program
-                for (Seenat& ref : kindInfo->GetSeenats())
-                {
-                    // determine an impact score
-                    impactScore += AnalyzeImpact(ref.m_where);
-                }
-            }
-        }
-    }
-
-    int IntermediateRepresentation::AnalyzeImpact(TokensLocation const& location)
-    {
-        // find the node at location:
-        return 0;
-    }
-
 }  // end of namespace AZ::ShaderCompiler

--- a/src/AzslcIntermediateRepresentation.cpp
+++ b/src/AzslcIntermediateRepresentation.cpp
@@ -518,7 +518,7 @@ namespace AZ::ShaderCompiler
             if (varInfo.GetTypeClass() == TypeClass::Enum)
             {
                 auto* asClassInfo = GetSymbolSubAs<ClassInfo>(varInfo.GetTypeId().GetName());
-                size = asClassInfo->Get<EnumerationInfo>()->m_underlyingType.m_arithmeticInfo.GetBaseSize();
+                size = asClassInfo->Get<EnumerationInfo>()->m_underlyingType.m_arithmeticInfo.m_baseSize;
             }
 
             nextMemberStartingOffset = Packing::PackNextChunk(layoutPacking, size, startAt);

--- a/src/AzslcIntermediateRepresentation.cpp
+++ b/src/AzslcIntermediateRepresentation.cpp
@@ -951,4 +951,29 @@ namespace AZ::ShaderCompiler
         return memberList[memberList.size() - 1];
     }
 
+    void IntermediateRepresentation::AnalyzeOptionRanks()
+    {
+        // loop over variables
+        for (auto& [uid, varInfo, kindInfo] : m_symbols.GetOrderedSymbolsOfSubType_3<VarInfo>())
+        {
+            // only options
+            if (varInfo->CheckHasStorageFlag(StorageFlag::Option))
+            {
+                int impactScore = 0;
+                // loop over appearances over the program
+                for (Seenat& ref : kindInfo->GetSeenats())
+                {
+                    // determine an impact score
+                    impactScore += AnalyzeImpact(ref.m_where);
+                }
+            }
+        }
+    }
+
+    int IntermediateRepresentation::AnalyzeImpact(TokensLocation const& location)
+    {
+        // find the node at location:
+        return 0;
+    }
+
 }  // end of namespace AZ::ShaderCompiler

--- a/src/AzslcIntermediateRepresentation.h
+++ b/src/AzslcIntermediateRepresentation.h
@@ -14,7 +14,6 @@
 
 namespace AZ::ShaderCompiler
 {
-
     //! We limit the maximum number of render targets to 8, with indices in the range [0..7]
     static const uint32_t kMaxRenderTargets = 8;
 
@@ -304,12 +303,6 @@ namespace AZ::ShaderCompiler
         // Returns info for the last variable inside the struct or class named @structUid.
         // If @structUid is not struct or class, then it returns nullptr.
         IdentifierUID GetLastMemberVariable(const IdentifierUID& structUid);
-
-        //! Determine a heurisitcal global order between options in the program, using "impacted code size" static analysis.
-        void AnalyzeOptionRanks();
-
-        //! Estimate a score proportional to how much code is "child" to the AST node at `location`
-        int AnalyzeImpact(TokensLocation const& location);
 
         // the maps of all variables, functions, etc, from the source code (things with declarations and a name).
         SymbolAggregator      m_symbols;

--- a/src/AzslcIntermediateRepresentation.h
+++ b/src/AzslcIntermediateRepresentation.h
@@ -305,6 +305,12 @@ namespace AZ::ShaderCompiler
         // If @structUid is not struct or class, then it returns nullptr.
         IdentifierUID GetLastMemberVariable(const IdentifierUID& structUid);
 
+        //! Determine a heurisitcal global order between options in the program, using "impacted code size" static analysis.
+        void AnalyzeOptionRanks();
+
+        //! Estimate a score proportional to how much code is "child" to the AST node at `location`
+        int AnalyzeImpact(TokensLocation const& location);
+
         // the maps of all variables, functions, etc, from the source code (things with declarations and a name).
         SymbolAggregator      m_symbols;
         // stateful helper during parsing

--- a/src/AzslcKindInfo.h
+++ b/src/AzslcKindInfo.h
@@ -248,7 +248,7 @@ namespace AZ::ShaderCompiler
         //! Get the size of a single element, ignoring array dimensions
         const uint32_t GetSingleElementSize(Packing::Layout layout, bool defaultRowMajor) const
         {
-            auto baseSize = m_coreType.m_arithmeticInfo.GetBaseSize();
+            auto baseSize = m_coreType.m_arithmeticInfo.m_baseSize;
             bool isRowMajor = (m_mtxMajor == Packing::MatrixMajor::RowMajor ||
                               (m_mtxMajor == Packing::MatrixMajor::Default && defaultRowMajor));
             auto rows = m_coreType.m_arithmeticInfo.m_rows;

--- a/src/AzslcKindInfo.h
+++ b/src/AzslcKindInfo.h
@@ -791,6 +791,7 @@ namespace AZ::ShaderCompiler
         vector< IdentifierUID >   m_overrides;                //!< list of implementing functions in child classes
         optional< IdentifierUID > m_base;   //!< points to the overridden function in the base interface, if applies. only supports one base
         FunctionMultiForwards     m_multiFwds    = FMF_None;  //!< presence of redundant prototype-only declarations
+        int                       m_costScore    = -1;        //!< heuristical static analysis of the amount of instructions contained
         struct Parameter
         {
             IdentifierUID m_varId;

--- a/src/AzslcKindInfo.h
+++ b/src/AzslcKindInfo.h
@@ -399,6 +399,7 @@ namespace AZ::ShaderCompiler
         ConstNumericVal            m_constVal;   // (attempted folded) initializer value for simple scalars
         optional<SamplerStateDesc> m_samplerState;
         ExtendedTypeInfo           m_typeInfoExt;
+        int                        m_estimatedCostImpact = -1;  //!< Cached value calculated by AnalyzeOptionRanks
     };
 
     // VarInfo methods definitions

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,8 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "17"  // last change: automatic option ranks
-                    // "16"          change: fixup runtime error with redundant function declarations
+#define AZSLC_REVISION "18"  // last change: automatic option ranks
 
 namespace AZ::ShaderCompiler
 {

--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,8 +23,8 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "16"  // last change: fixup runtime error with redundant function declarations
-                    // "15"          change: add min in option value key-extracter's function for range & enum
+#define AZSLC_REVISION "17"  // last change: automatic option ranks
+                    // "16"          change: fixup runtime error with redundant function declarations
 
 namespace AZ::ShaderCompiler
 {

--- a/src/AzslcReflection.cpp
+++ b/src/AzslcReflection.cpp
@@ -589,7 +589,7 @@ namespace AZ::ShaderCompiler
             else if (varInfo.GetTypeClass() == TypeClass::Enum)
             {
                 auto* asClassInfo = m_ir->GetSymbolSubAs<ClassInfo>(varInfo.GetTypeId().GetName());
-                size = asClassInfo->Get<EnumerationInfo>()->m_underlyingType.m_arithmeticInfo.GetBaseSize();
+                size = asClassInfo->Get<EnumerationInfo>()->m_underlyingType.m_arithmeticInfo.m_baseSize;
             }
 
             offset = Packing::PackNextChunk(layoutPacking, size, startAt);

--- a/src/AzslcReflection.cpp
+++ b/src/AzslcReflection.cpp
@@ -630,6 +630,8 @@ namespace AZ::ShaderCompiler
     void CodeReflection::DumpVariantList(const Options& options) const
     {
         m_out << GetVariantList(options);
+        m_out << "\n";
+        AnalyzeOptionRanks();
     }
 
     static void ReflectBinding(Json::Value& output, const RootSigDesc::SrgParamDesc& bindInfo)
@@ -857,7 +859,8 @@ namespace AZ::ShaderCompiler
         for (auto& seenat : kindInfo->GetSeenats())
         {
             assert(uid == seenat.m_referredDefinition);
-            // TODO: the assumption that intervals where distinct doesnt hold anymore now that we have unnamed scopes
+            // careful of the invariant: distinct intervals. (can't support functions nested in functions nor imbricated block scopes)
+            // ok for now because AZSL/HLSL don't have lambdas
             auto intervalIter = FindInterval(scopes, seenat.m_where.m_focusedTokenId, [](ssize_t key, auto& value)
                                              {
                                                  return value.first.properlyContains({key, key});
@@ -909,16 +912,9 @@ namespace AZ::ShaderCompiler
         uint32_t numOf32bitConst  = GetNumberOf32BitConstants(options, m_ir->m_rootConstantStructUID);
         RootSigDesc rootSignature = BuildSignatureDescription(options, numOf32bitConst);
 
-        // prepare a lookup acceleration data structure for reverse mapping tokens to scopes.
-        MapOfBeginToSpanAndUid scopeStartToFunctionIntervals;
-        for (auto& [uid, interval] : m_ir->m_scope.m_scopeIntervals)
-        {
-            if (m_ir->GetKind(uid) == Kind::Function)  // Filter out unnamed blocs and types. We need a set of disjoint intervals as an invariant for the next algorithm.
-            {
-                // the reason to choose .a as the key is so we can query using Infimum (sort of lower_bound)
-                scopeStartToFunctionIntervals[interval.a] = std::make_pair(interval, uid);
-            }
-        }
+        // Prepare a lookup acceleration data structure for reverse mapping tokens to scopes.
+        // (truth: we need a set of disjoint intervals as an invariant for the following algorithm)
+        GenerateScopeStartToFunctionIntervalsReverseMap();
 
         Json::Value srgRoot(Json::objectValue);
         // Order the reflection by SRG for convenience
@@ -968,7 +964,7 @@ namespace AZ::ShaderCompiler
                     else
                     {
                         set<IdentifierUID> dependencyList;
-                        DiscoverTopLevelFunctionDependencies(srgParam.m_uid, dependencyList, scopeStartToFunctionIntervals);
+                        DiscoverTopLevelFunctionDependencies(srgParam.m_uid, dependencyList, m_functionIntervals);
                         srgMember[srgParam.m_uid.GetNameLeaf()] = makeJsonNodeForOneResource(dependencyList, srgParam, {});
                     }
                 }
@@ -981,7 +977,7 @@ namespace AZ::ShaderCompiler
                     for (auto& srgConstant : srgInfo->m_implicitStruct.GetMemberFields())
                     {
                         allConstants.append({ srgConstant.GetNameLeaf() });
-                        DiscoverTopLevelFunctionDependencies(srgConstant, dependencyList, scopeStartToFunctionIntervals);
+                        DiscoverTopLevelFunctionDependencies(srgConstant, dependencyList, m_functionIntervals);
                     }
                     // variant fallback support
                     if (srgInfo->m_shaderVariantFallback)
@@ -992,7 +988,7 @@ namespace AZ::ShaderCompiler
                         {
                             if (varSub->CheckHasStorageFlag(StorageFlag::Option))
                             {
-                                DiscoverTopLevelFunctionDependencies(varUid, dependencyList, scopeStartToFunctionIntervals);
+                                DiscoverTopLevelFunctionDependencies(varUid, dependencyList, m_functionIntervals);
                             }
                         }
                     }
@@ -1003,5 +999,127 @@ namespace AZ::ShaderCompiler
         }
 
         m_out << srgRoot;
+    }
+
+    void CodeReflection::AnalyzeOptionRanks() const
+    {
+        // make sure we have the function scope lookup cache ready
+        GenerateScopeStartToFunctionIntervalsReverseMap();
+        // loop over variables
+        for (auto& [uid, varInfo, kindInfo] : m_ir->m_symbols.GetOrderedSymbolsOfSubType_3<VarInfo>())
+        {
+            // only options
+            if (varInfo->CheckHasStorageFlag(StorageFlag::Option))
+            {
+                int impactScore = 0;
+                // loop over appearances over the program
+                for (Seenat& ref : kindInfo->GetSeenats())
+                {
+                    // determine an impact score
+                    impactScore += AnalyzeImpact(ref.m_where)  // dependent code that may be skipped depending on the value of that ref
+                        + 1;  // by virtue of being mentioned (seenat), we count the reference as an access of cost 1.
+                }
+                m_out << "Option " << uid.GetName() << " has impact " << impactScore << "\n";
+            }
+        }
+    }
+
+    int CodeReflection::AnalyzeImpact(TokensLocation const& location) const
+    {
+        // find the node at `location`:
+        ParserRuleContext* node = m_ir->m_tokenMap.GetNode(location.m_focusedTokenId);
+        // go up tree to meet a block node that has visitable depth:
+        // can be any of if/for/while/switch
+        //  4 is an arbitrary depth, enough to search up things like `for (a, b<(ref+1), c)` binary op->braces->cmp expr->cond->for
+        if (auto* whileNode = DeepParentAs<azslParser::WhileStatementContext*>(node->parent, 3))
+        {
+            node = whileNode->embeddedStatement();
+        }
+        else if (auto* ifNode = DeepParentAs<azslParser::IfStatementContext*>(node->parent, 3))
+        {
+            node = ifNode->embeddedStatement();
+        }
+        else if (auto* forNode = DeepParentAs<azslParser::ForStatementContext*>(node->parent, 4))
+        {
+            node = forNode->embeddedStatement();
+        }
+        else if (auto* switchNode = DeepParentAs<azslParser::SwitchStatementContext*>(node->parent, 3))
+        {
+            node = switchNode->switchBlock();
+        }
+        int score = 0;
+        AnalyzeImpact(node, score);
+        return score;
+    }
+
+    void CodeReflection::AnalyzeImpact(ParserRuleContext* astNode, int& scoreAccumulator) const
+    {
+        for (auto& c : astNode->children)
+        {
+            if (auto* callNode = As<azslParser::FunctionCallExpressionContext*>(c))
+            {
+                // get function score in FunctionInfo if cached, compute it and store if not.
+                // to access the function symbol info we need the current scope, the function call name and perform a lookup.
+                auto intervalIter = FindInterval(m_functionIntervals, (ssize_t)callNode->start->getTokenIndex(),
+                                                 [](ssize_t key, auto& value)
+                                                 {
+                                                     return value.first.properlyContains({key, key});
+                                                 });
+                if (intervalIter != m_functionIntervals.cend())
+                {
+                    const IdentifierUID& encloser = intervalIter->second.second;
+                    // lookup function at AST node `callNode` from scope `encloser`
+                    if (auto* idExpr = As<azslParser::IdentifierExpressionContext*>(callNode->Expr))
+                    {
+                        UnqualifiedName funcName = ExtractNameFromIdExpression(idExpr->idExpression());
+                        m_ir->m_sema.ResolveOverload(
+                        IdAndKind* symbolMeantUnderCallNode = m_ir->m_symbols.LookupSymbol(encloser.GetName(), funcName);
+                        auto* funcInfo = symbolMeantUnderCallNode->second.GetSubAs<FunctionInfo>();
+                        if (funcInfo->m_costScore == -1)
+                        {
+                            funcInfo->m_costScore = 0;
+                            using AstFDef = azslParser::HlslFunctionDefinitionContext;
+                            AnalyzeImpact(polymorphic_downcast<AstFDef*>(funcInfo->m_defNode->parent)->block(),
+                                          funcInfo->m_costScore);  // recurse and cache if not already done
+                        }
+                        scoreAccumulator += funcInfo->m_costScore;
+                    }
+                    // other cases forfeited for now, but that would at least be braces (f)() or MAE x.m()
+                }
+                else // no interval found
+                {
+                    // function calls outside of function bodies can appear in an initializer:
+                    //    int g_a = MakeA();  // global init
+                    //    class C { int m_a = CompA();  // constructor init (invalid AZSL/HLSL)
+                    //    class D { void Method(int a_a = DefaultA());  // default parameter value
+                    // in any case, extracting the scope is impossible with this system.
+                    // we forfeit evaluation of a score
+                }
+            }
+            else if (auto* node = As<ParserRuleContext*>(c))
+            {
+                AnalyzeImpact(node, scoreAccumulator); // recurse down to make sure to capture embedded calls, like e.g. "x ? f() : 0;"
+            }
+            if (auto* leaf = As<tree::TerminalNode*>(c))
+            {
+                // determine cost by number of full expressions separated by semicolon
+                scoreAccumulator += leaf->getSymbol()->getType() == azslLexer::Semi;
+            }
+        }
+    }
+
+    void CodeReflection::GenerateScopeStartToFunctionIntervalsReverseMap() const
+    {
+        if (m_functionIntervals.empty())
+        {
+            for (auto& [uid, interval] : m_ir->m_scope.m_scopeIntervals)
+            {
+                if (m_ir->GetKind(uid) == Kind::Function)  // Filter out unnamed blocs and types.
+                {
+                    // the reason to choose .a as the key is so we can query using Infimum (sort of lower_bound)
+                    m_functionIntervals[interval.a] = std::make_pair(interval, uid);
+                }
+            }
+        }
     }
 }

--- a/src/AzslcReflection.cpp
+++ b/src/AzslcReflection.cpp
@@ -629,9 +629,9 @@ namespace AZ::ShaderCompiler
 
     void CodeReflection::DumpVariantList(const Options& options) const
     {
+        AnalyzeOptionRanks();
         m_out << GetVariantList(options);
         m_out << "\n";
-        AnalyzeOptionRanks();
     }
 
     static void ReflectBinding(Json::Value& output, const RootSigDesc::SrgParamDesc& bindInfo)
@@ -1060,7 +1060,7 @@ namespace AZ::ShaderCompiler
                     impactScore += AnalyzeImpact(ref.m_where)  // dependent code that may be skipped depending on the value of that ref
                         + 1;  // by virtue of being mentioned (seenat), we count the reference as an access of cost 1.
                 }
-                m_out << "Option " << uid.GetName() << " has impact " << impactScore << "\n";
+                varInfo->m_estimatedCostImpact = impactScore;
             }
         }
     }

--- a/src/AzslcReflection.h
+++ b/src/AzslcReflection.h
@@ -12,6 +12,7 @@
 namespace AZ::ShaderCompiler
 {
     using MapOfBeginToSpanAndUid = map<ssize_t, pair< misc::Interval, IdentifierUID> >;
+    using MapOfIntervalToUid = map<Interval<ssize_t>, IdentifierUID>;
 
     struct CodeReflection : Backend
     {
@@ -89,8 +90,10 @@ namespace AZ::ShaderCompiler
         void AnalyzeImpact(azslParser::FunctionCallExpressionContext* callNode, int& scoreAccumulator) const;
 
         //! Useful for static analysis on dependencies or option ranks
-        void GenerateScopeStartToFunctionIntervalsReverseMap() const;
-        mutable MapOfBeginToSpanAndUid m_functionIntervals; //< cache for the result of above function call
+        void GenerateTokenScopeIntervalToUidReverseMap() const;
+        mutable MapOfBeginToSpanAndUid m_functionIntervals;  //< only functions because they are guaranteed to be disjointed (largely simplifies queries)
+        mutable IntervalCollection<ssize_t> m_intervals;  //< augmented version with anonymous blocks (slower query)
+        mutable MapOfIntervalToUid m_intervalToUid;  //< side by side data since we don't want to weight the interval struct with a payload
 
         std::ostream& m_out;
     };

--- a/src/AzslcReflection.h
+++ b/src/AzslcReflection.h
@@ -85,6 +85,9 @@ namespace AZ::ShaderCompiler
         // Recursive internal detail version
         void AnalyzeImpact(ParserRuleContext* astNode, int& scoreAccumulator) const;
 
+        // Function-call specific
+        void AnalyzeImpact(azslParser::FunctionCallExpressionContext* callNode, int& scoreAccumulator) const;
+
         //! Useful for static analysis on dependencies or option ranks
         void GenerateScopeStartToFunctionIntervalsReverseMap() const;
         mutable MapOfBeginToSpanAndUid m_functionIntervals; //< cache for the result of above function call

--- a/src/AzslcSemanticOrchestrator.cpp
+++ b/src/AzslcSemanticOrchestrator.cpp
@@ -1205,37 +1205,19 @@ namespace AZ::ShaderCompiler
         TypeRefInfo typeInfoRhs = CreateTypeRefInfo(UnqualifiedNameView{rhs});
         if (typeInfoLhs.m_arithmeticInfo.IsEmpty() || typeInfoRhs.m_arithmeticInfo.IsEmpty())
         {   // Case that shouldn't work in AZSL yet (but may work in HLSL2021)
-            // -> UDT operator (would need support of operator overloading).
-            // We assume type is type of left expression.
-            // (what we really need to do is go get the return type of the overloaded operator)
+            //  -> UDT operator (would need support of operator overloading).
+            // We arbitrarily assume a result "type of left expression".
+            // (what we would really need to do is go get the return type of the overloaded operator)
             return lhs;
-        }
-        // After this is, both sides are arithmetic types (scalar, vector, matrix).
-        // matrix op vector is a forbidden case,
-        //  e.g it won't do Y=MX (m*v->v), nor dotproduct-ing vectors for that matter (v*v->scalar)
-        // It will do component to component op and return more or less the same type.
-        // In case of dimension differences, it will truncate to smaller type
-        //  e.g float2 + float3 results in float2 with .z lost in implicit cast
+        } // After this `if`, both sides are arithmetic types (scalar, vector, matrix).
+        // "matrix op vector" (or commutated) is a forbidden case,
+        //   e.g it won't do Y=MX (m*v->v), nor dotproduct-ing vectors for that matter (v*v->scalar)
+        // It will do piecewise `op` and return more or less the same type as the operands.
+        // In case of dimension differences, it will truncate to the smaller type
+        //   e.g float2 + float3 results in float2 with .z lost in implicit cast
         //      same for float2x3 * float2x2 (results in float2x2)
-        // We assume that for * + - / % ^ | & << >>
-        bool lhsIsVecMat = typeInfoLhs.m_typeClass.IsOneOf(TypeClass::Vector, TypeClass::Matrix);
-        bool rhsIsVecMat = typeInfoRhs.m_typeClass.IsOneOf(TypeClass::Vector, TypeClass::Matrix);
-        if (lhsIsVecMat !=/*xor*/ rhsIsVecMat)
-        {
-            auto scalarOperand = lhsIsVecMat ? typeInfoRhs : typeInfoLhs;
-            auto vecmatOperand = lhsIsVecMat ? typeInfoLhs : typeInfoRhs;
-            // typeof(vecmat op scalar)->promoted(vecmat)
-            return vecmatOperand.m_arithmeticInfo.PromoteTruncateWith(scalarOperand.m_arithmeticInfo).GenTypeId();
-        }
-        //else if (lhsIsVecMat && rhsIsVecMat)
-        {
-            // typeof(vecmat op vecmat)->promoted(truncated(vecmat))
-            return typeInfoLhs.m_arithmeticInfo.PromoteTruncateWith(typeInfoRhs.m_arithmeticInfo).GenTypeId();
-        }
-        // case left: both sides are scalar.
-        // final logic in case of arithmetic type class: integer/float promotion.
-        //return typeInfoLhs.m_arithmeticInfo.m_conversionRank > typeInfoRhs.m_arithmeticInfo.m_conversionRank ?
-        //    lhs : rhs;
+        // We assume that for all non bool ops: * + - / % ^ | & << >>
+        return PromoteTruncateWith({typeInfoLhs.m_arithmeticInfo, typeInfoRhs.m_arithmeticInfo}).GenTypeId();
     }
 
     QualifiedName SemanticOrchestrator::TypeofExpr(azslParser::ExpressionExtContext* ctx) const

--- a/src/AzslcSemanticOrchestrator.h
+++ b/src/AzslcSemanticOrchestrator.h
@@ -222,6 +222,9 @@ namespace AZ::ShaderCompiler
         auto TypeofExpr(azslParser::LiteralExpressionContext* ctx) const -> QualifiedName;
         auto TypeofExpr(azslParser::LiteralContext* ctx) const -> QualifiedName;
         auto TypeofExpr(azslParser::CommaExpressionContext* ctx) const -> QualifiedName;
+        auto TypeofExpr(azslParser::PostfixUnaryExpressionContext* ctx) const -> QualifiedName;
+        auto TypeofExpr(azslParser::PrefixUnaryExpressionContext* ctx) const -> QualifiedName;
+        auto TypeofExpr(azslParser::BinaryExpressionContext* ctx) const -> QualifiedName;
 
         //! Parse the AST from a variable declaration and attempt to extract array dimensions integer constants [dim1][dim2]...
         //! Return: <true> on success, <false> otherwise
@@ -330,7 +333,7 @@ namespace AZ::ShaderCompiler
         {
             auto typeId      = LookupType(typeNameOrCtx, policy);
             auto tClass      = GetTypeClass(typeId);
-            auto arithmetic  = IsNonGenericArithmetic(tClass) ? CreateArithmeticTypeInfo(typeId.GetName()) : ArithmeticTypeInfo{}; // TODO: canonicalize generics
+            auto arithmetic  = IsNonGenericArithmetic(tClass) ? CreateArithmeticTraits(typeId.GetName()) : ArithmeticTraits{}; // TODO: canonicalize generics
             return TypeRefInfo{typeId, arithmetic, tClass};
         }
 

--- a/src/AzslcSymbolAggregator.cpp
+++ b/src/AzslcSymbolAggregator.cpp
@@ -140,7 +140,7 @@ namespace AZ::ShaderCompiler
         {
             auto attempt = QualifiedName{JoinPath(path, name)};
             got = GetIdAndKindInfo(attempt);
-            exit = path == "/";
+            exit = path == "/" || path.empty();
             if (!got)
             {
                 if (auto* scopeAsClass = GetAsSub<ClassInfo>(IdentifierUID{GetParentName(attempt)})) // get enclosing class

--- a/src/AzslcSymbolAggregator.cpp
+++ b/src/AzslcSymbolAggregator.cpp
@@ -20,7 +20,7 @@ namespace AZ::ShaderCompiler
             auto& [uid, kindInfo] = st.AddIdentifier(azirName, Kind::Type);  // the kind is Type because all predefined are stored as such.
             auto& typeInfo        = kindInfo.GetSubAfterInitAs<Kind::Type>();
             auto typeClass        = TypeClass::FromStr(bag.m_name);
-            auto arithmetic       = IsNonGenericArithmetic(typeClass) ? CreateArithmeticTypeInfo(azirName) : ArithmeticTypeInfo{}; // TODO: canonicalize generics
+            auto arithmetic       = IsNonGenericArithmetic(typeClass) ? CreateArithmeticTraits(azirName) : ArithmeticTraits{}; // TODO: canonicalize generics
             typeInfo = TypeRefInfo{uid, arithmetic, typeClass};
         }
     }

--- a/src/AzslcUtils.h
+++ b/src/AzslcUtils.h
@@ -1047,6 +1047,13 @@ namespace AZ::ShaderCompiler
         return found ? found->argumentList() : nullptr;
     }
 
+    //! access the argument count at a function call site (from the AST)
+    inline size_t NumArgs(azslParser::FunctionCallExpressionContext* callCtx)
+    {
+        azslParser::ArgumentsContext* argsNode = callCtx->argumentList()->arguments();
+        return argsNode ? argsNode->expression().size() : 0;
+    }
+
     //! try to find a specific context type that this context would be a child of.
     template <typename LookedUp>
     inline LookedUp* ExtractSpecificParent(antlr4::ParserRuleContext* ctx)

--- a/src/AzslcUtils.h
+++ b/src/AzslcUtils.h
@@ -958,15 +958,22 @@ namespace AZ::ShaderCompiler
         return UnqualifiedName{ctx->Name->getText()};
     }
 
-    template <typename ParentType>
-    bool Is3ParentRuleOfType(antlr4::ParserRuleContext* ctx)
+    //! Get a pointer to the first parent that happens to be of type `SearchType`
+    //! with a limit depth of `maxDepth` parents to search through
+    template <typename SearchType>
+    SearchType DeepParentAs(tree::ParseTree* ctx, int maxDepth)
     {
-        if (ctx == nullptr || ctx->parent == nullptr || ctx->parent->parent == nullptr)  // input canonicalization
+        if (auto* searchTypeNode = As<SearchType>(ctx))
         {
-            return false;
+            return searchTypeNode;
         }
-        auto threeUp = ctx->parent->parent->parent;
-        return dynamic_cast<ParentType>(threeUp);
+        return maxDepth <= 0 || !ctx ? nullptr : DeepParentAs<SearchType>(ctx->parent, maxDepth - 1);
+    }
+
+    template <typename ParentType>
+    bool Is3ParentRuleOfType(tree::ParseTree* ctx)
+    {
+        return DeepParentAs<ParentType>(ctx, 3);
     }
 
     // is def

--- a/src/GenericUtils.h
+++ b/src/GenericUtils.h
@@ -379,14 +379,14 @@ namespace AZ
     // Is-One-Of will check if a variable is equal to any of the values listed on the other parameters.
     // Example: IsOneOf(variableKind, Function, Enumeration) is short for: variableKind == Function || variableKind == Enumeration.
     // 2 arguments count: recursion terminal overload.
-    template <typename T>
-    bool IsOneOf(T value, T tocheck)
+    template <typename T, typename U>
+    bool IsOneOf(T value, U tocheck)
     {
         return value == tocheck;
     }
     // Any argument count version
-    template <typename T, typename... Args>
-    bool IsOneOf(T value, T khead, Args... tail)
+    template <typename T, typename U, typename... Args>
+    bool IsOneOf(T value, U khead, Args... tail)
     {
         return value == khead || IsOneOf(value, tail...);
     }

--- a/src/GenericUtils.h
+++ b/src/GenericUtils.h
@@ -598,9 +598,9 @@ namespace AZ
     template< typename T >
     struct IntervalCollection
     {
-        using Interval = Interval<T>;
+        using IntervalT = Interval<T>;
 
-        void Add(Interval i)
+        void Add(IntervalT i)
         {
             m_obfirsts.emplace_back(i);
         }
@@ -621,7 +621,7 @@ namespace AZ
         }
 
         //! Retrieve the subset of intervals activated by a point (query)
-        set<Interval> GetIntervalsSurrounding(T query) const
+        set<IntervalT> GetIntervalsSurrounding(T query) const
         {
             assert(m_sealed);
             // find the "set" of intervals starting before:
@@ -630,7 +630,7 @@ namespace AZ
                                                  [=](auto interv, T q) { return interv.a <= q; });
 
             // find the "set" of intervals ending after:
-            static vector<Interval> endAfter;
+            static vector<IntervalT> endAfter;
             endAfter.clear();
             CopyIf(m_oblasts.rbegin(), m_oblasts.rend(),  // reverse iteration
                    [=](auto interv) { return interv.b >= query; },
@@ -639,7 +639,7 @@ namespace AZ
             // for set_intersection to work, the less<> predicate has to work for both ranges
             std::sort(endAfter.begin(), endAfter.end());
 
-            set<Interval> result;
+            set<IntervalT> result;
             std::set_intersection(m_obfirsts.begin(), firstsSubEnd,
                                   endAfter.begin(), endAfter.end(),
                                   std::inserter(result, result.end()));
@@ -651,14 +651,14 @@ namespace AZ
         //! each overlapping interval is fully contained in the bigger one,
         //! the closest start is guaranteed to be the most "leaf" interval.
         //! This is useful for scopes.
-        Interval GetClosestIntervalSurrounding(T query) const
+        IntervalT GetClosestIntervalSurrounding(T query) const
         {
             auto bag = GetIntervalsSurrounding(query);
-            return bag.empty() ? Interval{-1, -2} : *bag.rbegin();
+            return bag.empty() ? IntervalT{-1, -2} : *bag.rbegin();
         }
 
-        vector<Interval> m_obfirsts;  // ordered by "firsts"
-        vector<Interval> m_oblasts;   // ordered by "lasts"
+        vector<IntervalT> m_obfirsts;  // ordered by "firsts"
+        vector<IntervalT> m_oblasts;   // ordered by "lasts"
         bool m_sealed = false;
     };
 

--- a/src/GenericUtils.h
+++ b/src/GenericUtils.h
@@ -24,9 +24,9 @@ namespace AZ
     {
         using runtime_error::runtime_error;
     };
-    // Type-heterogeneity-preserving multi pointer object single visitor.
-    // Returns whatever the passed functor would.
-    // Throws if all passed objects are null.
+    //! Type-heterogeneity-preserving multi pointer object single visitor.
+    //! Returns whatever the passed functor would.
+    //! Throws if all passed objects are null.
     template <typename Lambda, typename T>
     invoke_result_t<Lambda, T*> VisitFirstNonNull(Lambda functor, T* object) noexcept(false)
     {
@@ -50,9 +50,9 @@ namespace AZ
         }
     }
 
-    // Create substring views of views. Works like python slicing operator [n:m] with limited modulo semantics.
-    // what I ultimately desire is the range v.3 feature eg `letters[{2,end-2}]`
-    // http://ericniebler.com/2014/12/07/a-slice-of-python-in-c/
+    //! Create substring views of views. Works like python slicing operator [n:m] with limited modulo semantics.
+    //! what I ultimately desire is the range v.3 feature eg `letters[{2,end-2}]`
+    //! http://ericniebler.com/2014/12/07/a-slice-of-python-in-c/
     inline constexpr string_view Slice(const string_view& in, int64_t st, int64_t end)
     {
         auto inSSize = (int64_t)in.size();
@@ -107,8 +107,8 @@ namespace AZ
     //https://developercommunity.visualstudio.com/content/problem/275141/c2131-expression-did-not-evaluate-to-a-constant-fo.html
     }
 
-    // ability to create size_t literals
-    // waiting for Working Group to get their stuff together https://groups.google.com/a/isocpp.org/forum/#!topic/std-proposals/tGoPjUeHlKo
+    //! ability to create size_t literals
+    //! waiting for Working Group to get their stuff together https://groups.google.com/a/isocpp.org/forum/#!topic/std-proposals/tGoPjUeHlKo
     inline constexpr std::size_t operator ""_sz(unsigned long long n)
     {
         return n;
@@ -145,7 +145,7 @@ namespace AZ
         return fileName.substr(0, lastIndex);
     }
 
-    // debug-build asserted dyn_cast, otherwise, release-build static_cast (idea from boost library)
+    //! debug-build asserted dyn_cast, otherwise, release-build static_cast (idea from boost library)
     template <typename To, typename From>
     To polymorphic_downcast(From instance)
     {
@@ -157,7 +157,7 @@ namespace AZ
         return static_cast<To>(instance);
     }
 
-    /// surround a string with a prefix and a suffix
+    //! surround a string with a prefix and a suffix
     inline string Decorate(string_view prefix, string_view body, string_view suffix)
     {
         std::stringstream ss;
@@ -167,13 +167,13 @@ namespace AZ
         return ss.str();
     }
 
-    /// 2 arguments version in case both sides are the same
+    //! 2 arguments version in case both sides are the same
     inline string Decorate(string_view prefixAndSuffix, string_view body)
     {
         return Decorate(prefixAndSuffix, body, prefixAndSuffix);
     }
 
-    /// reverse the effect of a symmetrical decoration
+    //! reverse the effect of a symmetrical decoration
     inline string_view Undecorate(string_view decoration, string_view body)
     {
         auto indexStart = StartsWith(body, decoration) ? decoration.length() : 0;
@@ -181,7 +181,7 @@ namespace AZ
         return Slice(body, indexStart, indexEnd);
     }
 
-    // Erase-Remove algorithm which removes all whitespaces from a string.
+    //! Erase-Remove algorithm which removes all whitespaces from a string.
     inline string RemoveWhitespaces(string haystack)
     {
         haystack.erase(std::remove_if(haystack.begin(), haystack.end(), [](unsigned char c) {return std::isspace(c); }), haystack.end());
@@ -193,14 +193,14 @@ namespace AZ
         return std::all_of(s.begin(), s.end(), [&](char c) { return std::isspace(c); });
     }
 
-    /// tells whether a position in a string is surrounded by round braces
-    /// e.g. true  for arguments {"a(b)", 2}
-    /// e.g. true  for arguments {"a()", 1}  by convention
-    /// e.g. false for arguments {"a()", 2}  by convention
-    /// e.g. false for arguments {"a(b)", 0}
-    /// e.g. false for arguments {"a(b)c", 4}
-    /// e.g. false for arguments {"a(b)c(d)", 4}
-    /// e.g. true  for arguments {"a((b)c(d))", 5}
+    //! tells whether a position in a string is surrounded by round braces
+    //! e.g. true  for arguments {"a(b)", 2}
+    //! e.g. true  for arguments {"a()", 1}  by convention
+    //! e.g. false for arguments {"a()", 2}  by convention
+    //! e.g. false for arguments {"a(b)", 0}
+    //! e.g. false for arguments {"a(b)c", 4}
+    //! e.g. false for arguments {"a(b)c(d)", 4}
+    //! e.g. true  for arguments {"a((b)c(d))", 5}
     inline bool WithinMatchedParentheses(string_view haystack, size_t charPosition)
     {
         const auto hayLen = haystack.length();
@@ -215,8 +215,8 @@ namespace AZ
         return nesting > 0;
     }
 
-    /// replace all occurrences of substring `sub` with substring `to` within haystack.
-    ///  e.g: Replace("aaa#aaa", "#", "_") gives-> "aaa_aaa"
+    //! replace all occurrences of substring `sub` with substring `to` within haystack.
+    //!  e.g: Replace("aaa#aaa", "#", "_") gives-> "aaa_aaa"
     inline string Replace(string haystack, string_view sub, string_view to)
     {
         decltype(sub.length()) pos = 0;
@@ -230,7 +230,7 @@ namespace AZ
         return haystack;
     }
 
-    // this one is inspired by the docopt utilities. trims whitespace by default, but can be used to trim quotes.
+    //! this one is inspired by the docopt utilities. trims whitespace by default, but can be used to trim quotes.
     constexpr inline string_view Trim(string_view haystack, string_view toTrim = " \t\n")
     {
         const auto strEnd = haystack.find_last_not_of(toTrim);
@@ -268,32 +268,54 @@ namespace AZ
         return std::find_if(begin, end, p) != end;
     }
 
-    /// argument in rangeV3-style version:
+    //! argument in rangeV3-style version:
     template< typename Container >
     string Join(const Container& c, string_view separator = "")
     {
         return Join(c.begin(), c.end(), separator);
     }
 
-    /// argument in rangeV3-style version:
+    //! argument in rangeV3-style version:
     template< typename Container, typename Predicate >
     bool Contains(const Container& c, Predicate p)
     {
         return Contains(c.begin(), c.end(), p);
     }
 
-    /// closest possible form of python's `in` keyword
+    //! closest possible form of python's `in` keyword
     template< typename Element, typename Container >
     bool IsIn(const Element& element, const Container& container)
     {
         return std::find(container.begin(), container.end(), element) != container.end();
     }
 
-    /// generate a new container with copy-and-mutated elements
+    //! generate a new container with copy-and-mutated elements
     template< typename Container, typename ContainerOut, typename Functor >
     void TransformCopy(const Container& in, ContainerOut& out, Functor mutator)
     {
         std::transform(in.begin(), in.end(), std::back_inserter(out), mutator);
+    }
+
+    enum class CopyIfPolicy { ForAll, InterruptAtFirstFalse };
+
+    //! inserts elements into the output iterator if they pass a predicate
+    template< typename InputIterator, typename Predicate, typename OutputIterator >
+    void CopyIf(InputIterator begin, InputIterator end,
+                Predicate pred,
+                OutputIterator out,
+                CopyIfPolicy policy)
+    {
+        for (auto it = begin; it != end; ++it)
+        {
+            if (pred(*it))
+            {
+                *out = *it;
+            }
+            else if (policy == CopyIfPolicy::InterruptAtFirstFalse)
+            {
+                break;
+            }
+        }
     }
 
     inline string Unescape(string_view escapedText)
@@ -531,7 +553,7 @@ namespace AZ
 #endif
     }
 
-    /// Log(N) find immediate lower element query in map-keys
+    //! Log(N) query to find the first immediately lower or equal element in a map's keys
     template< typename T, typename U >
     auto Infimum(map<T, U> const& ctr, T query)
     {
@@ -539,27 +561,98 @@ namespace AZ
         return it == ctr.begin() ? ctr.cend() : --it;
     }
 
-    /// Log(N) disjointed segments belong query
-    /// You can represent segments as you wish, as long as:
-    ///   you provide the predicate to determine belonging.
-    ///   map-keys are segment start points.
-    ///   segments don't overlap.
-    /// returns: iterator to found interval key, or cend()
+    //! Log(N) disjointed segments belong query
+    //! You can represent segments as you wish, as long as:
+    //!   you provide the predicate to determine belonging.
+    //!   map-keys are segment start points.
+    //!   segments don't overlap.
+    //! returns: iterator to found interval key, or cend()
     template< typename T, typename U, typename IntervalCheckPredicate >
-    auto FindInterval(const map<T, U>& ctr, const T& query, IntervalCheckPredicate&& isInIntervalPredicate)
+    auto FindIntervalInDisjointSet(const map<T, U>& ctr, const T& query, IntervalCheckPredicate&& isInIntervalPredicate)
     {
         auto inf = Infimum(ctr, query);
-        return inf == ctr.end() ? ctr.cend() : (isInIntervalPredicate(query, inf->second) ? inf : ctr.cend());
+        bool isInInterval = inf != ctr.cend() && isInIntervalPredicate(query, inf->second);
+        return isInInterval ? inf : ctr.cend();
     }
 
-    /// Log(N) disjointed segments belong query
-    /// segments are represented by their start points in the key, and last point in values. segments can't overlap.
-    /// returns: iterator to found interval key, or cend()
+    //! Log(N) disjointed segments belong query
+    //! segments are represented by their start points in the key, and last point in values. segments can't overlap.
+    //! returns: iterator to found interval key, or cend()
     template< typename T, typename U>
-    auto FindInterval(const map<T, U>& ctr, const T& query)
+    auto FindIntervalInDisjointSet(const map<T, U>& ctr, const T& query)
     {
-        return FindInterval(ctr, query, [](T q, U last) {return q <= last; });
+        return FindIntervalInDisjointSet(ctr, query, [](T q, U last) {return q <= last; });
     }
+
+    template< typename T >
+    struct Interval
+    {
+        bool IsEmpty() const { return b < a; }
+        bool operator== (Interval const& rhs) const { return a == rhs.a && b == rhs.b; }
+        bool operator< (Interval const& rhs) const { return a < rhs.a || (a == rhs.a && b < rhs.b); }
+        T a = (T)0;
+        T b = (T)-1;
+    };
+
+    //! In case of potential overlaps (not disjointed), this structure can support "is in" queries
+    template< typename T >
+    struct IntervalCollection
+    {
+        using Interval = Interval<T>;
+
+        //! Construction from an iterable collection of Interval typed elements
+        template< typename Iterator >
+        IntervalCollection(Iterator&& begin, Iterator&& end)
+            : m_obfirsts(begin, end), m_oblasts(begin, end)
+        {
+            std::sort(m_obfirsts.begin(), m_obfirsts.end(), [](auto i1, auto i2)
+                      {
+                          return i1.a < i2.a;
+                      });
+            std::sort(m_oblasts.begin(), m_oblasts.end(), [](auto i1, auto i2)
+                      {
+                          return i1.b < i2.b;
+                      });
+        }
+
+        //! Retrieve the subset of intervals activated by a point (query)
+        set<Interval> GetIntervalsSurrounding(T query)
+        {
+            // construct the set of intervals starting before:
+            set<Interval> startBefore;
+            CopyIf(m_obfirsts.begin(), m_obfirsts.end(),
+                   [=](auto interv) { return interv.a <= query; },
+                   std::inserter(startBefore, startBefore.end()),
+                   CopyIfPolicy::InterruptAtFirstFalse);  // because the obfirsts vector is sorted
+
+            // construct the set of intervals ending after:
+            set<Interval> endAfter;
+            CopyIf(m_oblasts.rbegin(), m_oblasts.rend(),  // reverse iteration
+                   [=](auto interv) { return interv.b >= query; },
+                   std::inserter(endAfter, endAfter.end()),
+                   CopyIfPolicy::InterruptAtFirstFalse);
+
+            set<Interval> result;
+            std::set_intersection(startBefore.begin(), startBefore.end(),
+                                  endAfter.begin(), endAfter.end(),
+                                  std::inserter(result, result.end()));
+            return result;
+        }
+
+        //! Get the interval surrounding query that has the closest start point to query.
+        //! In case of an interval collection representing a tree, that is,
+        //! each overlapping interval is fully contained in the bigger one,
+        //! the closest start is guaranteed to be the most "leaf" interval.
+        //! This is useful for scopes.
+        Interval GetClosestIntervalSurrounding(T query)
+        {
+            auto bag = GetIntervalsSurrounding(query);
+            return bag.empty() ? Interval{-1, -2} : *bag.rbegin();
+        }
+
+        vector<Interval> m_obfirsts;  // ordered by "firsts"
+        vector<Interval> m_oblasts;   // ordered by "lasts"
+    };
 
     template< typename Deduced >
     decltype(auto) CastToRValueReference(Deduced&& value)
@@ -567,7 +660,7 @@ namespace AZ
         return static_cast<std::remove_reference_t<Deduced>&&>(value);
     }
 
-    /// add a missing operator for convenience and shortness of code
+    //! add a missing operator for convenience and shortness of code
     inline bool operator == (string_view lhs, char rhs)
     {
         return lhs.length() == 1 && lhs[0] == rhs;
@@ -713,10 +806,10 @@ namespace AZ::Tests
             assert(yellow == intervals.cend());
             auto larger_than_all = Infimum(intervals, 15);
             assert(larger_than_all->first == 8);
-            assert(FindInterval(intervals, 4) != intervals.cend());
-            assert(FindInterval(intervals, 6) == intervals.cend());
-            assert(FindInterval(intervals, 8) != intervals.cend());
-            assert(FindInterval(intervals, 1) == intervals.cend());
+            assert(FindIntervalInDisjointSet(intervals, 4) != intervals.cend());
+            assert(FindIntervalInDisjointSet(intervals, 6) == intervals.cend());
+            assert(FindIntervalInDisjointSet(intervals, 8) != intervals.cend());
+            assert(FindIntervalInDisjointSet(intervals, 1) == intervals.cend());
 
             auto high = Infimum(intervals, 20);
             assert(high->first == 8);
@@ -734,6 +827,21 @@ namespace AZ::Tests
 
         assert(IsIn("hibou", std::initializer_list<const char*>{ "chouette", "hibou", "jay" }));
         assert(!IsIn("hibou", std::initializer_list<const char*>{ "chouette", "jay" }));
+
+        Interval<int> intvs[] = {{0,10}, {1,5}, {3,3}, {7,9}, {12,15}};
+        IntervalCollection<int> ic{std::begin(intvs), std::end(intvs)};
+        assert(ic.GetClosestIntervalSurrounding(-3).IsEmpty());
+        assert((ic.GetClosestIntervalSurrounding(0) == Interval<int>{0,10}));
+        assert((ic.GetClosestIntervalSurrounding(1) == Interval<int>{1,5}));
+        assert((ic.GetClosestIntervalSurrounding(3) == Interval<int>{3,3}));
+        assert((ic.GetClosestIntervalSurrounding(4) == Interval<int>{1,5}));
+        assert((ic.GetClosestIntervalSurrounding(6) == Interval<int>{0,10}));
+        assert((ic.GetClosestIntervalSurrounding(5) == Interval<int>{1,5}));
+        assert((ic.GetClosestIntervalSurrounding(7) == Interval<int>{7,9}));
+        assert((ic.GetClosestIntervalSurrounding(9) == Interval<int>{7,9}));
+        assert(ic.GetClosestIntervalSurrounding(11).IsEmpty());
+        assert((ic.GetClosestIntervalSurrounding(13) == Interval<int>{12,15}));
+        assert(ic.GetClosestIntervalSurrounding(16).IsEmpty());
     }
 }
 #endif

--- a/src/GenericUtils.h
+++ b/src/GenericUtils.h
@@ -624,6 +624,15 @@ namespace AZ
         RemoveDuplicatesKeepOrder(lhs);
     }
 
+    //! Conditional swap algorithm
+    template<typename T>
+    void SwapIf(T&& a, T&& b, bool condition)
+    {
+        if (condition)
+        {
+            std::swap(std::forward<T>(a), std::forward<T>(b));
+        }
+    }
 }
 
 #ifndef NDEBUG

--- a/src/MetaUtils.h
+++ b/src/MetaUtils.h
@@ -366,6 +366,10 @@ namespace AZ
 
     template <class Default, template<class...> class Op, class... Args>
     using DetectedOr_t = typename DetectedOr<Default, Op, Args...>::type;
+
+    //! define a Pair typealias that has two same T, without the need to repeat yourself
+    template <typename T>
+    using Pair = std::pair<T, T>;
 }
 
 #ifndef NDEBUG

--- a/src/PadToAttributeMutator.cpp
+++ b/src/PadToAttributeMutator.cpp
@@ -354,7 +354,7 @@ namespace AZ::ShaderCompiler
             else if (varInfo.GetTypeClass() == TypeClass::Enum)
             {
                 auto* asClassInfo = m_ir.GetSymbolSubAs<ClassInfo>(varInfo.GetTypeId().GetName());
-                size = asClassInfo->Get<EnumerationInfo>()->m_underlyingType.m_arithmeticInfo.GetBaseSize();
+                size = asClassInfo->Get<EnumerationInfo>()->m_underlyingType.m_arithmeticInfo.m_baseSize;
             }
 
             offset = Packing::PackNextChunk(layoutPacking, size, startAt);

--- a/tests/Advanced/mae-methodcall.azsl
+++ b/tests/Advanced/mae-methodcall.azsl
@@ -1,0 +1,27 @@
+ShaderResourceGroupSemantic slot0
+{
+    FrequencyId = 1;
+    ShaderVariantFallback = 128;
+};
+ShaderResourceGroup srg0 : slot0{}
+
+class C
+{
+    void f(double) { f(0) + f(0) * f(0) / f(0); f(0) - f(0) % f(0); }  // cost 7*7+2
+    void f(int) { ;;;;;;; }  // cost 7
+};
+
+option bool o;
+
+float4 main()
+{
+    if (o)  // unnamed block $bk0
+    {
+        C c;
+        {   // unnamed block $bk1 to verify lookup capability to find `/main/$bk0/c` from `/main/$bk0/$bk1/`
+            // understand that `c`'s type is `/C`, and use /C scope to lookup the f() method.
+            // also deep expression on LHS of MAE to give no break to the typeof system
+            (c).f(2 * 5.0l);   // double promotion in binary expression that resolves to double overload method call
+        }
+    }
+}

--- a/tests/Advanced/mae-methodcall.py
+++ b/tests/Advanced/mae-methodcall.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import sys
+import os
+sys.path.append("..")
+sys.path.append("../..")
+from clr import *
+import testfuncs
+
+
+def verifyOptionCosts(thefile, compilerPath, silent):
+    j, ok = testfuncs.buildAndGetJson(thefile, compilerPath, silent, ["--options"])
+    if ok:
+        predicates = []
+        # check all references of func()
+        predicates.append(lambda: j["ShaderOptions"][0]["name"] == "o")
+        predicates.append(lambda: j["ShaderOptions"][0]["costImpact"] == 54)
+
+        if not silent: print (fg.CYAN+ style.BRIGHT+ "option expected cost check..."+ style.RESET_ALL)
+        ok = testfuncs.verifyAllPredicates(predicates, j)
+    return ok
+
+result = 0  # to define for sub-tests
+resultFailed = 0
+
+def doTests(compiler, silent, azdxcpath):
+    global result
+    global resultFailed
+
+    # Working directory should have been set to this script's directory by the calling parent
+    # You can get it once doTests() is called, but not during initialization of the module,
+    #  because at that time it will still be set to the working directory of the calling script
+    workDir = os.getcwd()
+
+    if verifyOptionCosts(os.path.join(workDir, "mae-methodcall.azsl"), compiler, silent): result += 1
+    else: resultFailed += 1
+
+
+if __name__ == "__main__":
+    print ("please call from testapp.py")

--- a/tests/Semantic/AsError/overload-resolution-impossible-and-heteroreturn.azsl
+++ b/tests/Semantic/AsError/overload-resolution-impossible-and-heteroreturn.azsl
@@ -2,12 +2,13 @@ struct A {};
 struct B {};
 
 A make(int);
-B make(uint);
+B make(float);
 
 void main()
 {
     float x = 0.5;
-    A a = make((int)floor(x) + 1);  // #EC 41
+    A a = make(floor(x));  // #EC 41
+    //    make((int)floor(x));  // help azslc knowing about unregistered functions by casting to force the type.
 }
 /*Semantic Error 41: line 10::14 '(10): unable to match arguments (<fail>) to a registered overload. candidates are:
 /make(?int)

--- a/tests/Semantic/typeof-keyword.azsl
+++ b/tests/Semantic/typeof-keyword.azsl
@@ -19,7 +19,7 @@ top gettop();
 
 class A
 {
-	int a;
+    int a;
 };
 
 class B : A
@@ -83,16 +83,14 @@ void h()
     //   NumericConstructorExpression  float2(0,0)
     //   LiteralExpression             42
     //   CommaExpression               X, Y
-    // not supported:
     //   PostfixUnaryExpression        i++
     //   PrefixUnaryExpression         ++i
     //   BinaryExpression              i + j
-    // e.g. typeof(1 + 3) = <fail>
 
-     // mathematics
+    // mathematics
     __azslc_print_message("@check predicate ");
     __azslc_print_symbol(typeof(1 + 3), __azslc_prtsym_least_qualified);
-    __azslc_print_message(" == '<fail>'\n");
+    __azslc_print_message(" == 'int'\n");
 
     // literals
     __azslc_print_message("@check predicate ");
@@ -186,7 +184,7 @@ void h()
     __azslc_print_symbol(typeof(top::inner), __azslc_prtsym_fully_qualified);
     __azslc_print_message(" == '/top/inner'\n");
 
-	// class inheritance: parent member access using scope resolution operator
+    // class inheritance: parent member access using scope resolution operator
     __azslc_print_message("@check predicate ");
     __azslc_print_symbol(typeof(B::a), __azslc_prtsym_least_qualified);
     __azslc_print_message(" == 'int'\n");
@@ -445,4 +443,110 @@ void h()
     __azslc_print_message("@check predicate ");
     __azslc_print_symbol(typeof(INTVAR, INTVAR, DOUBLEVAR), __azslc_prtsym_least_qualified);
     __azslc_print_message(" == 'double'\n");
+
+    // binary arithmetic expression
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(1 + 1), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'int'\n");
+
+    // with float promotion
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(1 + 1.f), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'float'\n");
+
+    // with half promotion
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(1 + 1.h), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'half'\n");
+
+    // half and float to float promotion
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(1.f + 1.h), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'float'\n");
+
+    // int16_t to double promotion
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(1.l + int16_t(1)), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double'\n");
+
+    // bool binary
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(1.l && int16_t(1)), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'bool'\n");
+
+    // lookedup
+    double d;
+    int64_t i64;
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(d || i64), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'bool'\n");
+
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(d - i64), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double'\n");
+
+    // vector scalar
+    float4 f4;
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(2.f * f4), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'float4'\n");
+
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(f4 * 2.f), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'float4'\n");
+
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(d * f4), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double4'\n");
+
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(f4 * d), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double4'\n");
+
+    // matrix scalar
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(float() * float3x2()), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'float3x2'\n");
+
+    // matrix scalar with base type promotion
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(half3x2() * double()), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double3x2'\n");
+
+    // truncations
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(float3() * float2()), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'float2'\n");
+
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(float4x4() * float2x2()), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'float2x2'\n");
+
+    // truncate & upcast
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(float4x4() * double2x2()), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double2x2'\n");
+
+    // through alias
+    typealias d34m = double3x4;
+    typealias real = half;
+
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof((d34m)0 * (real)0), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double3x4'\n");
+    // note: the parser takes d32m() as a function call, this is the "most verxing parse" problem
+    //       float() is understood by the parser as a NumericConstructorExpression because it
+    //       has a list of the tokens representing all fundamental types.
+    //       but, with user defined identifiers, it can't branch into the "intended" context,
+    //       because ALL(*) Antlr4 parsers recognizes context free grammar only.
+    //       We could adopt a universal construction syntax Obj{} a la C++ for AZSL but it's not
+    //       compliant with the philosophy of not deviating from HLSL, which on its side doesn't really
+    //       accept constructor-type constructs. DXC just does it better here because clang parser is Turing complete.
+
+    d34m d34var;
+    real rVar;
+
+    __azslc_print_message("@check predicate ");
+    __azslc_print_symbol(typeof(rVar - d34var ), __azslc_prtsym_least_qualified);
+    __azslc_print_message(" == 'double3x4'\n");
 }


### PR DESCRIPTION
This is the branch to introduce static analysis for option ranks.

Here is a little history of the development of that branch.

### Idea

The main concept is to start from options's seenat (references throughout the code).
From a seenat, we determine its AST node, and find out if it's connected to a subtree.
Then we walk that tree recursively to accumulate the cost of its nodes.
![image](https://user-images.githubusercontent.com/25970839/230930135-254acfee-f8bd-449b-b599-1e978b00a57e.png)

Each time we encounter a function call node, we lookup that function by reconstructing the scope context at that position, and using the Lookup function. We establish the cost of the function, recursively and accumulate and cache function costs to memoize. (this is no typo, it's called memoization).

### Problems

## binary ops

We quickly encountered a problem of limitations of the type system by testing on StandardPBR, some function's overloads couldn't be decided, because of use of binary expressions:

This exception occurs and is interceptible and thus visible when run under the debugger:
![image](https://user-images.githubusercontent.com/25970839/230930671-edab6798-4db3-4c01-a376-79928030c6ad.png)

This is meant to be continuable, but will result in an internal <fail> type which can cause error #41 at times.
These are example of the contexts where StandardPBR hit such limit:
![image](https://user-images.githubusercontent.com/25970839/230930890-35494e7b-aecb-4b66-9af7-4cd2ecaa3574.png)

or
![image](https://user-images.githubusercontent.com/25970839/230930919-e3684c24-4ce7-4f58-a651-11be6fe535f4.png)


or 
![image](https://user-images.githubusercontent.com/25970839/230930951-876994c9-3e3e-4d56-a384-f3c789a4c8c1.png)

So, I implemented the binary expression solver for the type system to enrich the cost result.

## Methods

Method tracing is harder than free function calls because the starting scope is harder to figure out. I had to refactor the cost analyzer structure by taking inspiration from what's happening in the seenat system. I eventually found a streamlined implementation that only takes 3 supplementary lines of code by exploiting the TypeofExpr system. It supports a.b() but also a.A::b() or a.::A::b() as well.

## Scopes

I got a problem with the scope to IdentifierUID (symbol) map. Until now, the system to find out about the symbol covering a token space, was used by the --bindingdep system. It only used functions to populate that map.
The invariant was that functions never overloap, and we never have functions inside functions.
Therefore the set of intervals is disjoint.
It allowed for fast and simple queries using lower_bound (`Infimum` more exactly).
In our current case, we needed full scope reconstruction including inner scopes.
Therefore, the invariant was broken and I had to extend the map with a new class, called `IntervalCollection` which is much more powerful and can now support queries for the closest scope even in case of overlaps.
This is based on the mathematical idea that scopes (intervals) activated by a point are the `set intersection of the set_of_intervals_starting_earlier and set_of_intervals_ending_later`.
I tried to early-optimize that function as much as possible by avoiding temporary allocations, but `set` is a node based container so allocations are legion. We may recourse to Howard Hinnant stack allocator later.
That said, my benchmark found no measurable impact from that new system, this is the comparative run on StandardPBR:

![image](https://user-images.githubusercontent.com/25970839/230932515-82594309-a514-48b6-8b94-7bd294a47438.png)

we're probably good for now.

### Results of new features

Between a run with only the function follower, and the full system as it is now, we have a richer and better tracking of option costs, this is the difference between the early implementation and the last one with method follow and binary expressions:

![image](https://user-images.githubusercontent.com/25970839/230932699-7b8ca8c2-8c71-4614-9543-293441c86c84.png)

DirectionalLights is radically different notably.

This is it, the rest is in the commit messages and the code itself.

Bests.
