### PR TITLE
Fix a crash

### DIFF
--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -23,7 +23,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "18"  // last change: automatic option ranks
+#define AZSLC_REVISION "19"  // last change: fix crash in option ranks analysis in case of bodiless functions
 
 namespace AZ::ShaderCompiler
 {

--- a/src/AzslcReflection.cpp
+++ b/src/AzslcReflection.cpp
@@ -1194,9 +1194,12 @@ namespace AZ::ShaderCompiler
                     {
                         verboseCout << " " << concrete << " non-memoized. discovering cost\n";
                         funcInfo->m_costScore = 0;
-                        using AstFDef = azslParser::HlslFunctionDefinitionContext;
-                        AnalyzeImpact(polymorphic_downcast<AstFDef*>(funcInfo->m_defNode->parent)->block(),
-                                      funcInfo->m_costScore);  // recurse and cache
+                        if (funcInfo->m_defNode)  // undefined functions can't be explored
+                        {
+                            using AstFDef = azslParser::HlslFunctionDefinitionContext;
+                            AnalyzeImpact(polymorphic_downcast<AstFDef*>(funcInfo->m_defNode->parent)->block(),
+                                          funcInfo->m_costScore);  // recurse and cache
+                        }
                     }
                     scoreAccumulator += funcInfo->m_costScore;
                     verboseCout << " " << concrete << " cost score " << funcInfo->m_costScore << " added\n";


### PR DESCRIPTION
 in impact analysis caused by functions with no definition bodies.

This was discovered while working on shader management console, because of working with the latest version of standard PBR that has a late-user-implementation GetDepth function. No bodies are tolerated, so this PR fixes the fact that activating cost impact analysis makes azslc crash on them. This is not critical since the azslc binary that does that isn't live yet if I recall correctly.