### PR TITLE
Release 1.8.19

### DIFF
--- a/prepare_solution_win.bat
+++ b/prepare_solution_win.bat
@@ -8,7 +8,7 @@ REM
 
 set platform=win
 set architecture=x64
-set generator="Visual Studio 16 2019"
+set generator="Visual Studio 17 2022"
 
 set curr_dir=%~dp0
 set src_path=%curr_dir%\src

--- a/test.and.py
+++ b/test.and.py
@@ -20,7 +20,7 @@ from os.path import join, normpath, basename
 import re
 import importlib
 sys.path.append("tests")
-from clr import *
+from tests.clr import *
 
 testList = ['Syntax', 'Semantic', 'Advanced', 'Samples']
 

--- a/tests/testapp.py
+++ b/tests/testapp.py
@@ -12,7 +12,7 @@ import io
 from argparse import ArgumentParser
 from os.path import join, normpath, basename
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from clr import *
+from clr import fg, bg, style
 import re
 import testfuncs
 import importlib

--- a/tests/testapp.py
+++ b/tests/testapp.py
@@ -11,6 +11,7 @@ import os
 import io
 from argparse import ArgumentParser
 from os.path import join, normpath, basename
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from clr import *
 import re
 import testfuncs

--- a/tests/testapp.py
+++ b/tests/testapp.py
@@ -11,8 +11,15 @@ import os
 import io
 from argparse import ArgumentParser
 from os.path import join, normpath, basename
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from clr import fg, bg, style
+import inspect
+clrpath = os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), "clr.py")
+print(f"clr path is {clrpath}")
+import importlib.util
+spec = importlib.util.spec_from_file_location("clr", clrpath)
+clrmodule = importlib.util.module_from_spec(spec)
+sys.modules["clr"] = clrmodule
+spec.loader.exec_module(clrmodule)
+globals().update({v: vars(clrmodule)[v] for v in ["fg", "bg", "style"]})
 import re
 import testfuncs
 import importlib


### PR DESCRIPTION
I had to tweak some python imports to get them to work from the 
`$ python ../3p-package-scripts/o3de_package_scripts/build_package.py --search_path . azslc-1.8.19-rev1-windows`
command line.
It must have a different sort of current working directory or other environment interference, but it never got to reach the symbols in the clr module.
This change makes it work.