### PR TITLE
Update version

### DIFF
--- a/src/AzslcMain.cpp
+++ b/src/AzslcMain.cpp
@@ -25,7 +25,7 @@ namespace StdFs = std::filesystem;
 // For large features or milestones. Minor version allows for breaking changes. Existing tests can change.
 #define AZSLC_MINOR "8"   // last change: introduction of class inheritance
 // For small features or bug fixes. They cannot introduce breaking changes. Existing tests shouldn't change.
-#define AZSLC_REVISION "20"  // last change: update antlrv4 to 4.13.2
+#define AZSLC_REVISION "22"  // last change: Add support for depth SubpassInputs
 
 namespace AZ::ShaderCompiler
 {


### PR DESCRIPTION
Last git tag is [v1.8.22](https://github.com/o3de/o3de-azslc/releases/tag/1.8.22), I guess that is what `azslc --version` should say